### PR TITLE
clSparseArray

### DIFF
--- a/src/benchmarks/clsparse-bench/functions/clfunc_xCGM.hpp
+++ b/src/benchmarks/clsparse-bench/functions/clfunc_xCGM.hpp
@@ -16,27 +16,27 @@ class xCGM : public clsparseFunc
 {
 public:
     xCGM( PFCLSPARSETIMER sparseGetTimer, size_t profileCount, cl_device_type devType ):
-        clsparseFunc( devType, CL_QUEUE_PROFILING_ENABLE ), gpuTimer( nullptr ), cpuTimer( nullptr )
+        clsparseFunc( devType, CL_QUEUE_PROFILING_ENABLE ),/* gpuTimer( nullptr ),*/ cpuTimer( nullptr )
     {
         //	Create and initialize our timer class, if the external timer shared library loaded
         if( sparseGetTimer )
         {
-            gpuTimer = sparseGetTimer( CLSPARSE_GPU );
-            gpuTimer->Reserve( 1, profileCount );
-            gpuTimer->setNormalize( true );
+//            gpuTimer = sparseGetTimer( CLSPARSE_GPU );
+//            gpuTimer->Reserve( 1, profileCount );
+//            gpuTimer->setNormalize( true );
 
             cpuTimer = sparseGetTimer( CLSPARSE_CPU );
             cpuTimer->Reserve( 1, profileCount );
             cpuTimer->setNormalize( true );
 
-            gpuTimerID = gpuTimer->getUniqueID( "GPU xCGM", 0 );
+           // gpuTimerID = gpuTimer->getUniqueID( "GPU xCGM", 0 );
             cpuTimerID = cpuTimer->getUniqueID( "CPU xCGM", 0 );
         }
 
 
         clsparseEnableAsync( control, false );
 
-        solverControl = clsparseCreateSolverControl(100, VOID, 1e-2, 1e-8);
+        solverControl = clsparseCreateSolverControl(10000, NOPRECOND, 1e-4, 1e-8);
         clsparseSolverPrintMode(solverControl, NORMAL);
     }
 
@@ -50,16 +50,16 @@ public:
 
     void call_func()
     {
-        if( gpuTimer && cpuTimer )
+        if( /*gpuTimer && */cpuTimer )
         {
-          gpuTimer->Start( gpuTimerID );
+//          gpuTimer->Start( gpuTimerID );
           cpuTimer->Start( cpuTimerID );
 
           xCGM_Function(false);
 
 
           cpuTimer->Stop( cpuTimerID );
-          gpuTimer->Stop( gpuTimerID );
+//          gpuTimer->Stop( gpuTimerID );
         }
         else
         {
@@ -187,7 +187,7 @@ public:
                              sizeof( T ) * x.n, 0, NULL, NULL ), "::clEnqueueFillBuffer x.values" );
 
         // reset solverControl for next call
-        clsparseSetSolverParams(solverControl, 100, 1e-2, 1e-8, VOID);
+        clsparseSetSolverParams(solverControl, 10000, 1e-4, 1e-8, NOPRECOND);
     }
 
     void read_gpu_buffer( )
@@ -196,7 +196,7 @@ public:
 
     void cleanup( )
     {
-        if( gpuTimer && cpuTimer )
+        if(/* gpuTimer && */cpuTimer )
         {
           std::cout << "clSPARSE matrix: " << sparseFile << std::endl;
           size_t sparseBytes = sizeof( cl_int )*( csrMtx.nnz + csrMtx.m ) + sizeof( T ) * ( csrMtx.nnz + csrMtx.n + csrMtx.m );
@@ -206,7 +206,7 @@ public:
 
           //gpuTimer->pruneOutliers( 3.0 );
           //puTimer->Print( sparseBytes, "GiB/s" );
-          gpuTimer->Reset( );
+//          gpuTimer->Reset( );
         }
 
         //this is necessary since we are running a iteration of tests and calculate the average time. (in client.cpp)
@@ -229,7 +229,7 @@ private:
     void xCGM_Function( bool flush );
 
     //  Timers we want to keep
-    clsparseTimer* gpuTimer;
+   // clsparseTimer* gpuTimer;
     clsparseTimer* cpuTimer;
     size_t gpuTimerID, cpuTimerID;
 
@@ -253,7 +253,17 @@ template<> void
 xCGM<float>::xCGM_Function( bool flush )
 {
     // solve x from y = Ax
+    try {
     clsparseStatus status = clsparseScsrcg(&x, &csrMtx, &y, solverControl, control);
+    }
+    catch (std::out_of_range e)
+    {
+        std::cout << "e: " << std::endl;
+    }
+    catch (...)
+    {
+        std::cout << "xxx" << std::endl;
+    }
 
     if( flush )
         clFinish( queue );

--- a/src/include/clSPARSE.h
+++ b/src/include/clSPARSE.h
@@ -108,7 +108,7 @@ typedef enum _print_mode{
 
 typedef enum _precond
 {
-    VOID = 0,
+    NOPRECOND = 0,
     DIAGONAL
 } PRECONDITIONER;
 

--- a/src/library/blas1/cldense_axpby.hpp
+++ b/src/library/blas1/cldense_axpby.hpp
@@ -9,6 +9,8 @@
 
 #include "blas1/elementwise_operators.hpp"
 
+#include "internal/data_types/clarray.hpp"
+
 template<typename T, ElementWiseOperator OP = EW_PLUS>
 clsparseStatus
 axpby(cl_ulong size,
@@ -58,6 +60,60 @@ axpby(cl_ulong size,
     return clsparseSuccess;
 }
 
+
+//version for clsparse::array
+template<typename T, ElementWiseOperator OP = EW_PLUS>
+clsparseStatus
+axpby(clsparse::array<T>& pY,
+      const clsparse::array<T>& pAlpha,
+      const clsparse::array<T>& pX,
+      const clsparse::array<T>& pBeta,
+      const clsparseControl control)
+{
+
+    const int group_size = 256; // this or higher? control->max_wg_size?
+
+    const std::string params = std::string()
+            + " -DSIZE_TYPE=" + OclTypeTraits<cl_ulong>::type
+            + " -DVALUE_TYPE=" + OclTypeTraits<T>::type
+            + " -DWG_SIZE=" + std::to_string( group_size )
+            + " -D" + ElementWiseOperatorTrait<OP>::operation;
+
+    cl::Kernel kernel = KernelCache::get(control->queue, "blas1", "axpby",
+                                         params);
+
+    KernelWrap kWrapper(kernel);
+
+    cl_ulong size = pY.size();
+
+    //clsparse do not support offset;
+    cl_ulong offset = 0;
+
+    kWrapper << size
+             << pY.buffer()
+             << offset
+             << pAlpha.buffer()
+             << offset
+             << pX.buffer()
+             << offset
+             << pBeta.buffer()
+             << offset;
+
+    int blocksNum = (size + group_size - 1) / group_size;
+    int globalSize = blocksNum * group_size;
+
+    cl::NDRange local(group_size);
+    cl::NDRange global (globalSize);
+
+    cl_int status = kWrapper.run(control, global, local);
+
+    if (status != CL_SUCCESS)
+    {
+        return clsparseInvalidKernelExecution;
+    }
+
+    return clsparseSuccess;
+}
 
 
 #endif //_CLSPARSE_AXPBY_HPP_

--- a/src/library/blas1/cldense_axpy.hpp
+++ b/src/library/blas1/cldense_axpy.hpp
@@ -8,6 +8,7 @@
 #include "internal/clsparse_internal.hpp"
 
 #include "elementwise_operators.hpp"
+#include "internal/data_types/clarray.hpp"
 
 template<typename T, ElementWiseOperator OP = EW_PLUS>
 clsparseStatus
@@ -37,6 +38,54 @@ axpy(cl_ulong size,
              << pAlpha->offset()
              << pX->values
              << pX->offset();
+
+    int blocksNum = (size + group_size - 1) / group_size;
+    int globalSize = blocksNum * group_size;
+
+    cl::NDRange local(group_size);
+    cl::NDRange global (globalSize);
+
+    cl_int status = kWrapper.run(control, global, local);
+
+    if (status != CL_SUCCESS)
+    {
+        return clsparseInvalidKernelExecution;
+    }
+
+    return clsparseSuccess;
+}
+
+
+template<typename T, ElementWiseOperator OP = EW_PLUS>
+clsparseStatus
+axpy(clsparse::array<T>& pY,
+     const clsparse::array<T>& pAlpha,
+     const clsparse::array<T>& pX,
+     const clsparseControl control)
+{
+    const int group_size = 256; // this or higher? control->max_wg_size?
+
+    const std::string params = std::string()
+            + " -DSIZE_TYPE=" + OclTypeTraits<cl_ulong>::type
+            + " -DVALUE_TYPE=" + OclTypeTraits<T>::type
+            + " -DWG_SIZE=" + std::to_string( group_size )
+            + " -D" + ElementWiseOperatorTrait<OP>::operation;
+
+    cl::Kernel kernel = KernelCache::get(control->queue, "blas1", "axpy",
+                                         params);
+
+    KernelWrap kWrapper(kernel);
+
+    cl_ulong size = pY.size();
+    cl_ulong offset = 0;
+
+    kWrapper << size
+             << pY.buffer()
+             << offset
+             << pAlpha.buffer()
+             << offset
+             << pX.buffer()
+             << offset;
 
     int blocksNum = (size + group_size - 1) / group_size;
     int globalSize = blocksNum * group_size;

--- a/src/library/blas1/cldense_dot.cpp
+++ b/src/library/blas1/cldense_dot.cpp
@@ -6,6 +6,18 @@ cldenseSdot (clsparseScalar* r,
              const clsparseVector* y,
              const clsparseControl control)
 {
+    if (!clsparseInitialized)
+    {
+        return clsparseNotInitialized;
+    }
+
+    //check opencl elements
+    if (control == nullptr)
+    {
+        return clsparseInvalidControlObject;
+    }
+
+
     clsparseScalarPrivate* pR = static_cast<clsparseScalarPrivate*>( r );
     const clsparseVectorPrivate* pX = static_cast<const clsparseVectorPrivate*> ( x );
     const clsparseVectorPrivate* pY = static_cast<const clsparseVectorPrivate*> ( y );
@@ -19,6 +31,18 @@ cldenseDdot (clsparseScalar* r,
              const clsparseVector* y,
              const clsparseControl control)
 {
+    if (!clsparseInitialized)
+    {
+        return clsparseNotInitialized;
+    }
+
+    //check opencl elements
+    if (control == nullptr)
+    {
+        return clsparseInvalidControlObject;
+    }
+
+
     clsparseScalarPrivate* pDot = static_cast<clsparseScalarPrivate*>( r );
     const clsparseVectorPrivate* pX = static_cast<const clsparseVectorPrivate*> ( x );
     const clsparseVectorPrivate* pY = static_cast<const clsparseVectorPrivate*> ( y );

--- a/src/library/blas1/cldense_dot.hpp
+++ b/src/library/blas1/cldense_dot.hpp
@@ -8,6 +8,7 @@
 
 #include "commons.hpp"
 #include "atomic_reduce.hpp"
+#include "internal/data_types/clarray.hpp"
 
 template<typename T>
 clsparseStatus
@@ -59,16 +60,6 @@ clsparseStatus dot(clsparseScalarPrivate* pR,
                    const clsparseVectorPrivate* pY,
                    const clsparseControl control)
 {
-    if (!clsparseInitialized)
-    {
-        return clsparseNotInitialized;
-    }
-
-    //check opencl elements
-    if (control == nullptr)
-    {
-        return clsparseInvalidControlObject;
-    }
 
     cl_int status;
 
@@ -122,8 +113,111 @@ clsparseStatus dot(clsparseScalarPrivate* pR,
     }
 
     return clsparseSuccess;
-
 }
 
+/*
+ * clsparse::array
+ */
+template<typename T>
+clsparseStatus
+inner_product (clsparse::array<T>& partial,
+     const clsparse::array<T>& pX,
+     const clsparse::array<T>& pY,
+     const cl_ulong size,
+     const cl_ulong REDUCE_BLOCKS_NUMBER,
+     const cl_ulong REDUCE_BLOCK_SIZE,
+     const clsparseControl control)
+{
+
+    cl_ulong nthreads = REDUCE_BLOCK_SIZE * REDUCE_BLOCKS_NUMBER;
+
+    std::string params = std::string()
+            + " -DSIZE_TYPE=" + OclTypeTraits<cl_ulong>::type
+            + " -DVALUE_TYPE=" + OclTypeTraits<T>::type
+            + " -DWG_SIZE=" + std::to_string(REDUCE_BLOCK_SIZE)
+            + " -DREDUCE_BLOCK_SIZE=" + std::to_string(REDUCE_BLOCK_SIZE)
+            + " -DN_THREADS=" + std::to_string(nthreads);
+
+    cl::Kernel kernel = KernelCache::get(control->queue,
+                                         "dot", "inner_product", params);
+
+    KernelWrap kWrapper(kernel);
+
+    kWrapper << size
+             << partial.buffer()
+             << pX.buffer()
+             << pY.buffer();
+
+    cl::NDRange local(REDUCE_BLOCK_SIZE);
+    cl::NDRange global(REDUCE_BLOCKS_NUMBER * REDUCE_BLOCK_SIZE);
+
+
+    cl_int status = kWrapper.run(control, global, local);
+
+    if (status != CL_SUCCESS)
+    {
+        return clsparseInvalidKernelExecution;
+    }
+
+    return clsparseSuccess;
+}
+
+template<typename T>
+clsparseStatus dot(clsparse::array<T>& pR,
+                   const clsparse::array<T>& pX,
+                   const clsparse::array<T>& pY,
+                   const clsparseControl control)
+{
+
+    cl_int status;
+
+    //not necessary to have it, but remember to init the pR with the proper value
+    init_scalar(pR, (T)0, control);
+
+    // with REDUCE_BLOCKS_NUMBER = 256 final reduction can be performed
+    // within one block;
+    const cl_ulong REDUCE_BLOCKS_NUMBER = 256;
+
+    /* For future optimisation
+    //workgroups per compute units;
+    const cl_uint  WG_PER_CU = 64;
+    const cl_ulong REDUCE_BLOCKS_NUMBER = control->max_compute_units * WG_PER_CU;
+    */
+    const cl_ulong REDUCE_BLOCK_SIZE = 256;
+
+    cl_ulong xSize = pX.size();
+    cl_ulong ySize = pY.size();
+
+    assert (xSize == ySize);
+
+    cl_ulong size = xSize;
+
+    if (size > 0)
+    {
+        cl::Context context = control->getContext();
+
+        //partial result
+        clsparse::array<T> partial(control, REDUCE_BLOCKS_NUMBER, 0,
+                                   CL_MEM_READ_WRITE, false);
+
+        status = inner_product<T>(partial, pX, pY, size,  REDUCE_BLOCKS_NUMBER,
+                               REDUCE_BLOCK_SIZE, control);
+
+        if (status != clsparseSuccess)
+        {
+            return clsparseInvalidKernelExecution;
+        }
+
+       status = atomic_reduce<T>(pR, partial, REDUCE_BLOCK_SIZE,
+                                     control);
+
+        if (status != CL_SUCCESS)
+        {
+            return clsparseInvalidKernelExecution;
+        }
+    }
+
+    return clsparseSuccess;
+}
 
 #endif //_CLSPARSE_DOT_HPP_

--- a/src/library/blas1/cldense_nrm1.cpp
+++ b/src/library/blas1/cldense_nrm1.cpp
@@ -6,6 +6,17 @@ cldenseSnrm1(clsparseScalar* s,
              const clsparseVector* x,
              const clsparseControl control)
 {
+    if (!clsparseInitialized)
+    {
+        return clsparseNotInitialized;
+    }
+
+    //check opencl elements
+    if (control == nullptr)
+    {
+        return clsparseInvalidControlObject;
+    }
+
     clsparseScalarPrivate* pS = static_cast<clsparseScalarPrivate*> ( s );
     const clsparseVectorPrivate* pX = static_cast<const clsparseVectorPrivate*> ( x );
 
@@ -18,6 +29,17 @@ cldenseDnrm1(clsparseScalar* s,
              const clsparseVector* x,
              const clsparseControl control)
 {
+    if (!clsparseInitialized)
+    {
+        return clsparseNotInitialized;
+    }
+
+    //check opencl elements
+    if (control == nullptr)
+    {
+        return clsparseInvalidControlObject;
+    }
+
     clsparseScalarPrivate* pS = static_cast<clsparseScalarPrivate*> ( s );
     const clsparseVectorPrivate* pX = static_cast<const clsparseVectorPrivate*> ( x );
 

--- a/src/library/blas1/cldense_nrm1.hpp
+++ b/src/library/blas1/cldense_nrm1.hpp
@@ -15,4 +15,16 @@ Norm1(clsparseScalarPrivate* pS,
     return reduce<T, RO_FABS>(pS, pX, control);
 }
 
+/*
+ * clsparse::array
+ */
+template<typename T>
+clsparseStatus
+Norm1(clsparse::array<T>& pS,
+      const clsparse::array<T>& pX,
+      const clsparseControl control)
+{
+    return reduce<T, RO_FABS>(pS, pX, control);
+}
+
 #endif //_CLSPARSE_NRM_1_HPP_

--- a/src/library/blas1/cldense_nrm2.cpp
+++ b/src/library/blas1/cldense_nrm2.cpp
@@ -6,6 +6,17 @@ cldenseSnrm2(clsparseScalar* s,
              const clsparseVector* x,
              const clsparseControl control)
 {
+    if (!clsparseInitialized)
+    {
+        return clsparseNotInitialized;
+    }
+
+    //check opencl elements
+    if (control == nullptr)
+    {
+        return clsparseInvalidControlObject;
+    }
+
     clsparseScalarPrivate* pS = static_cast<clsparseScalarPrivate*> ( s );
     const clsparseVectorPrivate* pX = static_cast<const clsparseVectorPrivate*> ( x );
 
@@ -18,6 +29,17 @@ cldenseDnrm2(clsparseScalar* s,
              const clsparseVector* x,
              const clsparseControl control)
 {
+    if (!clsparseInitialized)
+    {
+        return clsparseNotInitialized;
+    }
+
+    //check opencl elements
+    if (control == nullptr)
+    {
+        return clsparseInvalidControlObject;
+    }
+
     clsparseScalarPrivate* pS = static_cast<clsparseScalarPrivate*> ( s );
     const clsparseVectorPrivate* pX = static_cast<const clsparseVectorPrivate*> ( x );
 

--- a/src/library/blas1/cldense_nrm2.hpp
+++ b/src/library/blas1/cldense_nrm2.hpp
@@ -13,5 +13,17 @@ Norm2(clsparseScalarPrivate* pS,
     return reduce<T, RO_SQR, RO_SQRT>(pS, pX, control);
 }
 
+/*
+ * clsparse::array
+ */
+template<typename T>
+clsparseStatus
+Norm2(clsparse::array<T>& pS,
+      const clsparse::array<T>& pX,
+      const clsparseControl control)
+{
+    return reduce<T, RO_SQR, RO_SQRT>(pS, pX, control);
+}
+
 
 #endif //_CLSPARSE_NRM_2_HPP_

--- a/src/library/blas1/cldense_reduce.cpp
+++ b/src/library/blas1/cldense_reduce.cpp
@@ -14,6 +14,17 @@ cldenseSreduce(clsparseScalar *s,
                const clsparseVector *x,
                const clsparseControl control)
 {
+    if (!clsparseInitialized)
+    {
+        return clsparseNotInitialized;
+    }
+
+    //check opencl elements
+    if (control == nullptr)
+    {
+        return clsparseInvalidControlObject;
+    }
+
     clsparseScalarPrivate* pSum = static_cast<clsparseScalarPrivate*> ( s );
     const clsparseVectorPrivate* pX = static_cast<const clsparseVectorPrivate*> ( x );
 
@@ -25,6 +36,17 @@ cldenseDreduce(clsparseScalar *s,
                const clsparseVector *x,
                const clsparseControl control)
 {
+    if (!clsparseInitialized)
+    {
+        return clsparseNotInitialized;
+    }
+
+    //check opencl elements
+    if (control == nullptr)
+    {
+        return clsparseInvalidControlObject;
+    }
+
     clsparseScalarPrivate* pSum = static_cast<clsparseScalarPrivate*> ( s );
     const clsparseVectorPrivate* pX = static_cast<const clsparseVectorPrivate*> ( x );
 

--- a/src/library/blas1/commons.hpp
+++ b/src/library/blas1/commons.hpp
@@ -3,7 +3,7 @@
 #define _CLSPARSE_COMMONS_HPP_
 
 #include "include/clSPARSE-private.hpp"
-
+#include "internal/data_types/clarray.hpp"
 template <typename T>
 inline void init_scalar(clsparseScalarPrivate* scalar, T value,
                         const clsparseControl control)
@@ -13,6 +13,13 @@ inline void init_scalar(clsparseScalarPrivate* scalar, T value,
     T* fR = rScalar.clMapMem( CL_TRUE, CL_MAP_WRITE, scalar->offset(), 1);
 
     *fR  = value;
+}
+
+template <typename T>
+inline void init_scalar(clsparse::array<T>& scalar, T value,
+                        const clsparseControl control)
+{
+    scalar.fill(control, value);
 }
 
 

--- a/src/library/blas1/elementwise_transform.hpp
+++ b/src/library/blas1/elementwise_transform.hpp
@@ -9,6 +9,10 @@
 
 #include "elementwise_operators.hpp"
 
+#include "internal/data_types/clarray.hpp"
+
+
+
 /* Elementwise operation on two vectors
 */
 
@@ -48,6 +52,61 @@ elementwise_transform(clsparseVectorPrivate* r,
     KernelWrap kWrapper (kernel);
 
     kWrapper << size << r->values << x->values << y->values;
+
+    int blocks = (size + wg_size - 1) / wg_size;
+
+    cl::NDRange local(wg_size);
+    cl::NDRange global(blocks * wg_size);
+
+    cl_int status = kWrapper.run(control, global, local);
+
+    if (status != CL_SUCCESS)
+    {
+        return clsparseInvalidKernelExecution;
+    }
+
+    return clsparseSuccess;
+}
+
+/*
+ * clsparse::array
+ */
+template<typename T, ElementWiseOperator OP>
+clsparseStatus
+elementwise_transform(clsparse::array<T>& r,
+                      const clsparse::array<T>& x,
+                      const clsparse::array<T>& y,
+                      clsparseControl control)
+{
+    if (!clsparseInitialized)
+    {
+        return clsparseNotInitialized;
+    }
+
+    //check opencl elements
+    if (control == nullptr)
+    {
+        return clsparseInvalidControlObject;
+    }
+
+    assert(x.size() == y.size());
+    assert(x.size() == r.size());
+
+    cl_ulong size = x.size();
+    cl_uint wg_size = 256;
+
+    std::string params = std::string()
+            + " -DSIZE_TYPE=" + OclTypeTraits<cl_ulong>::type
+            + " -DVALUE_TYPE=" + OclTypeTraits<T>::type
+            + " -DWG_SIZE=" + std::to_string(wg_size)
+            + " -D" + ElementWiseOperatorTrait<OP>::operation;
+
+    cl::Kernel kernel = KernelCache::get(control->queue, "elementwise_transform",
+                                         "transform", params);
+
+    KernelWrap kWrapper (kernel);
+
+    kWrapper << size << r.buffer() << x.buffer() << y.buffer();
 
     int blocks = (size + wg_size - 1) / wg_size;
 

--- a/src/library/blas1/reduce.hpp
+++ b/src/library/blas1/reduce.hpp
@@ -127,5 +127,106 @@ reduce(clsparseScalarPrivate* pR,
     return clsparseSuccess;
 }
 
+/*
+ * clsparse::array version
+ */
+
+template <typename T, ReduceOperator OP>
+clsparseStatus
+global_reduce (clsparse::array<T>& partial,
+               const clsparse::array<T>& pX,
+               const cl_ulong REDUCE_BLOCKS_NUMBER,
+               const cl_ulong REDUCE_BLOCK_SIZE,
+               const clsparseControl control)
+{
+    cl_ulong nthreads = REDUCE_BLOCK_SIZE * REDUCE_BLOCKS_NUMBER;
+
+    std::string params = std::string()
+            + " -DSIZE_TYPE=" + OclTypeTraits<cl_ulong>::type
+            + " -DVALUE_TYPE=" + OclTypeTraits<T>::type
+            + " -DWG_SIZE=" + std::to_string(REDUCE_BLOCK_SIZE)
+            + " -DREDUCE_BLOCK_SIZE=" + std::to_string(REDUCE_BLOCK_SIZE)
+            + " -DN_THREADS=" + std::to_string(nthreads)
+            + " -D" + ReduceOperatorTrait<OP>::operation;
+
+    cl::Kernel kernel = KernelCache::get(control->queue,
+                                         "reduce", "reduce", params);
+
+    KernelWrap kWrapper(kernel);
+
+    cl_ulong size = pX.size();
+
+    kWrapper << size
+             << pX.buffer()
+             << partial.buffer();
+
+    cl::NDRange local(REDUCE_BLOCK_SIZE);
+    cl::NDRange global(REDUCE_BLOCKS_NUMBER * REDUCE_BLOCK_SIZE);
+
+
+    cl_int status = kWrapper.run(control, global, local);
+
+    if (status != CL_SUCCESS)
+    {
+        return clsparseInvalidKernelExecution;
+    }
+
+    return clsparseSuccess;
+
+}
+
+// G_OP: Global reduce operation
+// F_OP: Final reduce operation, modifies final result of the reduce operation
+template<typename T, ReduceOperator G_OP, ReduceOperator F_OP = RO_DUMMY>
+clsparseStatus
+reduce(clsparse::array<T>& pR,
+       const clsparse::array<T>& pX,
+       const clsparseControl control)
+{
+
+
+    // with REDUCE_BLOCKS_NUMBER = 256 final reduction can be performed
+    // within one block;
+    const cl_ulong REDUCE_BLOCKS_NUMBER = 256;
+
+    /* For future optimisation
+    //workgroups per compute units;
+    const cl_uint  WG_PER_CU = 64;
+    const cl_ulong REDUCE_BLOCKS_NUMBER = control->max_compute_units * WG_PER_CU;
+    */
+    const cl_ulong REDUCE_BLOCK_SIZE = 256;
+
+    init_scalar(pR, (T)0, control);
+
+    cl_int status;
+    if (pX.size() > 0)
+    {
+        cl::Context context = control->getContext();
+
+        //vector for partial sums of X;
+        clsparse::array<T> partial(control, REDUCE_BLOCKS_NUMBER, 0,
+                                   CL_MEM_READ_WRITE, false);
+
+        status = global_reduce<T, G_OP>(partial, pX, REDUCE_BLOCKS_NUMBER,
+                                      REDUCE_BLOCK_SIZE, control);
+
+        if (status != CL_SUCCESS)
+        {
+            return clsparseInvalidKernelExecution;
+        }
+
+        clsparseStatus clsp_status =
+                atomic_reduce<T, F_OP>(pR, partial, REDUCE_BLOCK_SIZE, control);
+
+
+        if (clsp_status!= CL_SUCCESS)
+        {
+            return clsp_status;
+        }
+    }
+
+    return clsparseSuccess;
+}
+
 
 #endif //_CLSPARSE_REDUCE_HPP_

--- a/src/library/internal/data_types/clarray_base.hpp
+++ b/src/library/internal/data_types/clarray_base.hpp
@@ -56,9 +56,9 @@ public:
 
     array_base() = default;
     array_base(const array_base&) = delete;
-    array_base(array_base&&) = default;
+    //array_base(array_base&&) = default;
     array_base& operator=(const array_base&) = delete;
-    array_base& operator=(array_base&&) = default;
+    //array_base& operator=(array_base&&) = default;
 
 protected:
     BUFF_TYPE buff;

--- a/src/library/solvers/conjugate_gradients.hpp
+++ b/src/library/solvers/conjugate_gradients.hpp
@@ -1,4 +1,4 @@
-#pragma #once
+#pragma once
 #ifndef _CLSPARSE_SOLVER_CG_HPP_
 #define _CLSPARSE_SOLVER_CG_HPP_
 
@@ -26,162 +26,6 @@
  * be found here:
  * http://www.cs.cmu.edu/~./quake-papers/painless-conjugate-gradient.pdf
  */
-#define CLSP_ERRCHK(ans) { clsparseCheck((ans), __FILE__, __LINE__); }
-
-inline void clsparseCheck(cl_int code, const char *file, int line, bool abort=false)
-{
-   if (code != CL_SUCCESS)
-   {
-      std::cerr << "clsparse assert: " << code << " " << file << " " << line << std::endl;
-      if (abort) exit(code);
-   }
-}
-
-
-// To keep the code more clear at the moment I've provided those functions for
-// copying functions for vector and scalars
-template <typename T>
-inline cl_int
-clsparseCpyVectorBuffers(const clsparseVectorPrivate* src,
-                         clsparseVectorPrivate* dst,
-                         clsparseControl control)
-{
-    cl_int status;
-#if (BUILD_CLVERSION < 200)
-            status = clEnqueueCopyBuffer(control->queue(), src->values, dst->values,
-                            src->offset(), dst->offset(),
-                            src->n * sizeof(T),
-                            control->event_wait_list.size(),
-                            &(control->event_wait_list.front())(),
-                            &control->event( )
-                            );
-#else
-            status clEnqueueSVMMemcpy(control->queue(), CL_TRUE,
-                           dst->values, src->values, src->n * sizeof(T),
-                           control->event_wait_list.size(),
-                           &(control->event_wait_list.front())(),
-                           &control->event( ));
-#endif
-    return status;
-}
-
-template <typename T>
-inline cl_int
-clsparseCpyScalarBuffers(const clsparseScalarPrivate* src,
-                         clsparseScalarPrivate* dst,
-                         clsparseControl control)
-{
-    cl_int status;
-#if (BUILD_CLVERSION < 200)
-            status = clEnqueueCopyBuffer(control->queue(), src->value, dst->value,
-                            src->offset(), dst->offset(),
-                            sizeof(T),
-                            control->event_wait_list.size(),
-                            &(control->event_wait_list.front())(),
-                            &control->event( )
-                            );
-#else
-            status clEnqueueSVMMemcpy(control->queue(), CL_TRUE,
-                           dst->value, src->value, sizeof(T),
-                           control->event_wait_list.size(),
-                           &(control->event_wait_list.front())(),
-                           &control->event( ));
-#endif
-    return status;
-}
-
-template <typename T>
-inline cl_int
-clsparse_alloc_init_vector(clsparseVectorPrivate& vec, T value, clsparseControl control, bool fill = true)
-{
-    cl_int status;
-    cl_context ctx = control->getContext()();
-
-    vec.values = clCreateBuffer(ctx, CL_MEM_READ_WRITE, sizeof(T) * vec.n, NULL, &status);
-    CLSP_ERRCHK(status);
-
-    if (fill)
-    {
-        status = clEnqueueFillBuffer(control->queue(), vec.values, &value, sizeof(T), 0,
-                            sizeof(T) * vec.n, 0, NULL, NULL);
-        CLSP_ERRCHK(status);
-    }
-
-    return status;
-}
-
-template <typename T>
-inline cl_int
-clsparse_alloc_init_scalar(clsparseScalarPrivate& scalar, T value, clsparseControl control, bool fill = true)
-{
-    cl_int status;
-    cl_context ctx = control->getContext()();
-
-    scalar.value = clCreateBuffer(ctx, CL_MEM_READ_WRITE, sizeof(T), NULL, &status);
-    CLSP_ERRCHK(status);
-
-    if (fill)
-    {
-        status = clEnqueueFillBuffer(control->queue(), scalar.value, &value, sizeof(T), 0,
-                            sizeof(T), 0, NULL, NULL);
-        CLSP_ERRCHK(status);
-    }
-    return status;
-}
-
-template <typename T>
-inline cl_int
-display_vector(const clsparseVectorPrivate& v, clsparseControl control, std::string info = "")
-{
-    {
-        size_t size = v.n;
-        clMemRAII<T> r_temp(control->queue(), v.values);
-        T* f_temp = r_temp.clMapMem(CL_TRUE, CL_MAP_READ, 0, size);
-
-        std::cout << info << std::endl;
-        for (int i = 0; i < 5; i++)
-        {
-            std::cout << f_temp[i] << std::endl;
-        }
-        std::cout << "..." << std::endl;
-        for (int i = size - 5; i < size; i++)
-        {
-            std::cout << f_temp[i] << std::endl;
-        }
-    }
-
-}
-
-template <typename T>
-inline cl_int
-display_scalar(const clsparseScalarPrivate& s, clsparseControl control, std::string info = "")
-{
-    {
-        size_t size = 1;
-        clMemRAII<T> r_temp(control->queue(), s.value);
-        T* f_temp = r_temp.clMapMem(CL_TRUE, CL_MAP_READ, 0, size);
-
-        std::cout << info << " = " << *f_temp << std::endl;
-    }
-}
-
-template <typename T>
-inline cl_int
-display_matrix(const clsparseCsrMatrix& m, clsparseControl control)
-{
-    clMemRAII<T> r_v(control->queue(), m.values);
-    T* f_v = r_v.clMapMem(CL_TRUE, CL_MAP_READ, 0, m.nnz);
-
-    for (int i = 0; i < m.nnz; i++)
-    {
-        std::cout << f_v[i] << std::endl;
-    }
-}
-
-
-
-
-
 template<typename T, typename PTYPE>
 clsparseStatus
 cg(clsparseVectorPrivate *pX,
@@ -198,152 +42,68 @@ cg(clsparseVectorPrivate *pX,
     {
         return clsparseInvalidSystemSize;
     }
+
+    //opaque input parameters with clsparse::array type;
+    clsparse::array<T> x(control, pX->values, pX->n);
+    clsparse::array<T> b(control, pB->values, pB->n);
+
     cl_int status;
 
     T scalarOne = 1;
     T scalarZero = 0;
 
-    cl_context ctx = control->getContext()();
-
-//    clsparse::array<T> x(control, 10, 1.2);
-
-//    clsparse::array<T> x2(control, 15, 0.1);
-//    x2 = x;
-//    clsparse::array<T> x3(x2);
-
-//    std::cout << "X2 content: " << x2.size() << std::endl;
-//    for(int i = 0; i < x2.size(); i++)
-//    {
-//        std::cout << x2[i] << std::endl;
-//    }
-
-//    std::cout << "X3 content: " << x3.size() << std::endl;
-//    for(int i = 0; i < x3.size(); i++)
-//    {
-//        std::cout << x3[i] << std::endl;
-//        x3[i] = 0.9;
-//    }
-
-//    clsparse::array<T> x4 = x3;
-//    x4[6] = 199;
-
-//    std::cout << "All arrays: " << std::endl;
-//    for(int i = 0; i < x3.size(); i++)
-//    {
-//        std::cout << x[i] << " "
-//                  << x2[i] << " "
-//                  << x3[i] << " "
-//                  << x4[i] << std::endl;
-
-//    }
-
-//      return clsparseSuccess;
-
-
-
-
-    clsparseScalarPrivate norm_b;
-    clsparseInitScalar(&norm_b);
-    status = clsparse_alloc_init_scalar(norm_b, scalarZero, control, false);
-    CLSP_ERRCHK(status);
-
+    clsparse::array<T> norm_b(control, 1, 0, CL_MEM_WRITE_ONLY, true);
 
     //norm of rhs of equation
-    status = Norm1<T>(&norm_b, pB, control);
-    CLSP_ERRCHK(status);
+    status = Norm1<T>(norm_b, b, control);
+    OPENCL_V_THROW(status, "Norm B Failed");
 
     //norm_b is calculated once
-    T h_norm_b = 0;
-
-    //we do not have explicit unmap function defined so I'm doing this in that way
-    {
-        clMemRAII<T> m_norm_b(control->queue(), norm_b.value);
-        T* f_norm_b = m_norm_b.clMapMem(CL_TRUE, CL_MAP_READ, 0, 1);
-        h_norm_b = *f_norm_b;
+    T h_norm_b = norm_b[0];
 
 #ifndef NDEBUG
-        std::cout << "norm_b " << h_norm_b << std::endl;
+    std::cout << "norm_b " << h_norm_b << std::endl;
 #endif
 
-        if (h_norm_b == 0) //special case b is zero so solution is x = 0
-        {
-            solverControl->nIters = 0;
-            solverControl->absoluteTolerance = 0.0;
-            solverControl->relativeTolerance = 0.0;
-
-            //we can either fill the x with zeros or cpy b to x;
-            status = clsparseCpyVectorBuffers<T>(pB, pX, control);
-            CLSP_ERRCHK(status);
-            return clsparseSuccess;
-        }
+    if (h_norm_b == 0) //special case b is zero so solution is x = 0
+    {
+        solverControl->nIters = 0;
+        solverControl->absoluteTolerance = 0.0;
+        solverControl->relativeTolerance = 0.0;
+        //we can either fill the x with zeros or cpy b to x;
+        x = b;
+        return clsparseSuccess;
     }
+
 
     //continuing "normal" execution of cg algorithm
     const auto N = pA->n;
 
     //helper containers, all need to be zeroed
-    clsparseVectorPrivate y;
-    clsparseInitVector(&y);
-    y.n = N;
-    status = clsparse_alloc_init_vector(y, scalarZero, control);
-    CLSP_ERRCHK(status);
+    clsparse::array<T> y(control, N, 0, CL_MEM_READ_WRITE, true);
+    clsparse::array<T> z(control, N, 0, CL_MEM_READ_WRITE, true);
+    clsparse::array<T> r(control, N, 0, CL_MEM_READ_WRITE, true);
+    clsparse::array<T> p(control, N, 0, CL_MEM_READ_WRITE, true);
 
-
-    clsparseVectorPrivate z;
-    clsparseInitVector(&z);
-    z.n = N;
-    status = clsparse_alloc_init_vector(z, scalarZero, control);
-    CLSP_ERRCHK(status);
-
-
-    clsparseVectorPrivate r;
-    clsparseInitVector(&r);
-    r.n = N;
-    status = clsparse_alloc_init_vector(r, scalarZero, control, false);
-    CLSP_ERRCHK(status);
-
-
-    clsparseVectorPrivate p;
-    clsparseInitVector(&p);
-    p.n = N;
-    status = clsparse_alloc_init_vector(p, scalarZero, control, false);
-    CLSP_ERRCHK(status);
-
-    //TODO: Change sAlpha to one, bEta to 0;?
-    clsparseScalarPrivate sAlpha;
-    clsparseInitScalar(&sAlpha);
-    status = clsparse_alloc_init_scalar(sAlpha, scalarOne, control);
-    CLSP_ERRCHK(status);
-
-
-    clsparseScalarPrivate sBeta;
-    clsparseInitScalar(&sBeta);
-    status = clsparse_alloc_init_scalar(sBeta, scalarZero, control);
-    CLSP_ERRCHK(status);
+    clsparse::array<T> one(control, 1, 1, CL_MEM_READ_ONLY, true);
+    clsparse::array<T> zero(control, 1, 0, CL_MEM_READ_ONLY, true);
 
     // y = A*x
-    status = csrmv<T>(&sAlpha, pA, pX, &sBeta, &y, control);
-    CLSP_ERRCHK(status);
+    status = csrmv<T>(one, pA, x, zero, y, control);
+    OPENCL_V_THROW(status, "csrmv Failed");
 
     //r = b - y
-    status = elementwise_transform<T, EW_MINUS>(&r, pB, &y, control);
-    CLSP_ERRCHK(status);
+    status = elementwise_transform<T, EW_MINUS>(r, b, y, control);
+    OPENCL_V_THROW(status, "b - y Failed");
 
-    clsparseScalarPrivate norm_r;
-    clsparseInitScalar(&norm_r);
-    clsparse_alloc_init_scalar(norm_r, scalarZero, control, false);
-
-    //calculate norm of r
-    status = Norm1<T>(&norm_r, &r, control);
-    CLSP_ERRCHK(status);
+    clsparse::array<T> norm_r(control, 1, 0, CL_MEM_WRITE_ONLY, true);
+    status = Norm1<T>(norm_r, r, control);
+    OPENCL_V_THROW(status, "norm r Failed");
 
     T residuum = 0;
     {
 
-        clMemRAII<T> m_norm_r(control->queue(), norm_r.value);
-        T* f_norm_r = m_norm_r.clMapMem(CL_TRUE, CL_MAP_READ, 0, 1);
-
-        residuum = *f_norm_r / h_norm_b;
+        residuum = norm_r[0] / h_norm_b;
 #ifndef NDEBUG
         std::cout << "initial residuum = " << residuum << std::endl;
 #endif
@@ -355,148 +115,89 @@ cg(clsparseVectorPrivate *pX,
         solverControl->nIters = 0;
         return clsparseSuccess;
     }
-
     //apply preconditioner z = M*r
-    M(&r, &z, control);
+    M(r, z, control);
 
     //copy inital z to p
-    status = clsparseCpyVectorBuffers<T>(&z, &p, control);
-    CLSP_ERRCHK(status);
+    p = z;
 
     //rz = <r, z>, here actually should be conjugate(r)) but we do not support complex type.
-    clsparseScalarPrivate rz;
-    clsparseInitScalar(&rz);
-    status = clsparse_alloc_init_scalar(rz, scalarZero, control, false);
-    CLSP_ERRCHK(status);
-
-    status = dot<T>(&rz, &r, &z, control);
-    CLSP_ERRCHK(status);
+    clsparse::array<T> rz(control, 1, 0, CL_MEM_WRITE_ONLY, true);
+    status = dot<T>(rz, r, z, control);
+    OPENCL_V_THROW(status, "<r, z> Failed");
 
     int iteration = 0;
 
     bool converged = false;
 
-    clsparseScalarPrivate alpha;
-    clsparseInitScalar(&alpha);
-    clMemRAII<T> m_alpha(control->queue(), &alpha.value, 1);
-
-    clsparseScalarPrivate beta;
-    clsparseInitScalar(&beta);
-    clMemRAII<T> m_beta(control->queue(), &beta.value, 1);
+    clsparse::array<T> alpha (control, 1, 0, CL_MEM_READ_WRITE, true);
+    clsparse::array<T> beta  (control, 1, 0, CL_MEM_READ_WRITE, true);
 
     //yp buffer for inner product of y and p vectors;
-    clsparseScalarPrivate yp;
-    clsparseInitScalar(&yp);
-    clMemRAII<T> m_yp(control->queue(), &yp.value, 1);
+    clsparse::array<T> yp(control, 1, 0, CL_MEM_WRITE_ONLY, true);
 
-    clsparseScalarPrivate rz_old;
-    clsparseInitScalar(&rz_old);
-    clMemRAII<T> m_rz_old(control->queue(), &rz_old.value, 1);
+    clsparse::array<T> rz_old(control, 1, 0, CL_MEM_WRITE_ONLY, true);
 
     while(!converged)
     {
         solverControl->nIters = iteration;
 
         //y = A*p
-        status = csrmv<T>(&sAlpha, pA, &p, &sBeta, &y, control);
-        CLSP_ERRCHK(status);
+        status = csrmv<T>(one, pA, p, zero, y, control);
+        OPENCL_V_THROW(status, "csrmv Failed");
 
 
-        status = dot<T>(&yp, &y, &p, control);
-        CLSP_ERRCHK(status);
+        status = dot<T>(yp, y, p, control);
+        OPENCL_V_THROW(status, "<y,p> Failed");
 
         // alpha = <r,z> / <y,p>
-        {
-            clMemRAII<T> r_alpha(control->queue(), alpha.value);
-            T* f_alpha = r_alpha.clMapMem(CL_TRUE, CL_MAP_WRITE, 0, 1);
+        alpha[0] = rz[0] / yp[0];
 
-            clMemRAII<T> r_rz(control->queue(), rz.value);
-            T* f_rz = r_rz.clMapMem(CL_TRUE, CL_MAP_READ, 0, 1);
-
-            clMemRAII<T> r_yp(control->queue(), yp.value);
-            T* f_yp = r_yp.clMapMem(CL_TRUE, CL_MAP_READ, 0, 1);
-
-            *f_alpha = *f_rz / *f_yp;
 #ifndef NDEBUG
-            std::cout << "alpha = " << *f_alpha << std::endl;
+            std::cout << "alpha = " << alpha[0] << std::endl;
 #endif
-        }
 
         //x = x + alpha*p
-        status = axpy<T>(pX->n, pX, &alpha, &p, control);
-        CLSP_ERRCHK(status);
+        status = axpy<T>(x, alpha, p, control);
+        OPENCL_V_THROW(status, "x = x + alpha * p Failed");
 
         //r = r - alpha * y;
-        status = axpy<T, EW_MINUS>(r.n, &r, &alpha, &y, control);
-        CLSP_ERRCHK(status);
+        status = axpy<T, EW_MINUS>(r, alpha, y, control);
+        OPENCL_V_THROW(status, "r = r - alpha * y Failed");
+
 
         //apply preconditioner z = M*r
-        M(&r, &z, control);
+        M(r, z, control);
 
         //store old value of rz
-        status = clsparseCpyScalarBuffers<T>(&rz, &rz_old, control);
-        CLSP_ERRCHK(status);
+        rz_old = rz;
 
         //rz = <r,z>
-        status = dot<T>(&rz, &r, &z, control);
-        CLSP_ERRCHK(status);
+        status = dot<T>(rz, r, z, control);
+        OPENCL_V_THROW(status, "<r,z> Failed");
 
         // beta = <r^(i), r^(i)>/<r^(i-1),r^(i-1)> // i: iteration index;
         // beta is ratio of dot product in current iteration compared
-        // to previous.
-        {
-            clMemRAII<T> r_beta(control->queue(), beta.value);
-            T* f_beta = r_beta.clMapMem(CL_TRUE, CL_MAP_WRITE, 0, 1);
-
-            clMemRAII<T> r_rz(control->queue(), rz.value);
-            T* f_rz = r_rz.clMapMem(CL_TRUE, CL_MAP_READ, 0, 1);
-
-
-            clMemRAII<T> r_rz_old(control->queue(), rz_old.value);
-            T* f_rz_old = r_rz_old.clMapMem(CL_TRUE, CL_MAP_READ, 0, 1);
-
-            *f_beta = *f_rz / *f_rz_old;
+        beta[0] = rz[0] / rz_old[0];
 #ifndef NDEBUG
-            std::cout << "beta = " << *f_beta << std::endl;
+            std::cout << "beta = " << beta[0] << std::endl;
 #endif
-        }
 
         //p = z + beta*p;
-        //TODO: change name sAlpha to "one"
-        status = axpby<T>(p.n, &p, &sAlpha, &z, &beta, control );
-        CLSP_ERRCHK(status);
+        status = axpby<T>(p, one, z, beta, control );
+        OPENCL_V_THROW(status, "p = z + beta*p Failed");
 
         //calculate norm of r
-        status = Norm1<T>(&norm_r, &r, control);
-        CLSP_ERRCHK(status);
+        status = Norm1<T>(norm_r, r, control);
+        OPENCL_V_THROW(status, "norm r Failed");
 
-        {
-
-            clMemRAII<T> m_norm_r(control->queue(), norm_r.value);
-            T* f_norm_r = m_norm_r.clMapMem(CL_TRUE, CL_MAP_READ, 0, 1);
-
-            residuum = *f_norm_r / h_norm_b;
-
-        }
+        residuum = norm_r[0] / h_norm_b;
 
         iteration++;
         converged = solverControl->finished(residuum);
 
         solverControl->print();
-
     }
-
-    clReleaseMemObject(norm_b.value);
-    clReleaseMemObject(y.values);
-    clReleaseMemObject(z.values);
-    clReleaseMemObject(r.values);
-    clReleaseMemObject(p.values);
-
-    clReleaseMemObject(sAlpha.value);
-    clReleaseMemObject(sBeta.value);
-
-    clReleaseMemObject(norm_r.value);
-    clReleaseMemObject(rz.value);
 
     return clsparseSuccess;
 }

--- a/src/library/solvers/preconditioners/diagonal.hpp
+++ b/src/library/solvers/preconditioners/diagonal.hpp
@@ -8,6 +8,7 @@
 
 #include "blas1/elementwise_transform.hpp"
 #include "preconditioner_utils.hpp"
+#include "internal/data_types/clarray.hpp"
 #include <memory>
 
 /* The simplest preconditioner consists of just the
@@ -30,76 +31,33 @@ class DiagonalPreconditioner
 {
 public:
     DiagonalPreconditioner(const clsparseCsrMatrixPrivate* A,
-                           clsparseControl control)
+                           clsparseControl control) :
+        invDiag_A(control, min(A->m, A->n), 0, CL_MEM_READ_WRITE, false)
     {
-        //allocate proper size assuming rectangular size of A;
-        cl_uint size = std::min(A->m, A->n);
-
-        clsparseInitVector(&invDiag_A);
-        invDiag_A.n = size;
 
         cl_int status;
 
-        clMemRAII<T> r_invDiag_A (control->queue(),
-                                  &invDiag_A.values, invDiag_A.n,
-                                                CL_MEM_READ_WRITE);
-
-        // I dont want to clMemRAII release this object in constructor
-        // but the problem will be in openCL 20
-        // write operator= for clMemRAII then extend this class with field
-        // of this type which will manage the invDiag_A.
-#if (BUILD_CLVERSION < 200)
-        status = ::clRetainMemObject(invDiag_A.values);
-#endif
-
-        if( status != CL_SUCCESS )
-        {
-            std::cout << "Problem with creating invDiag buffer"
-                      << " (" << status << ")" << std::endl;
-        }
         // extract inverse diagonal from matrix A and store it in invDiag_A
         // easy to check with poisson matrix;
-        status = extract_diagonal<T, true>(&invDiag_A, A, control);
-
-        if( status != CL_SUCCESS )
-        {
-            std::cout << "Invalid extract_diagonal kernel execution " << std::endl;
-        }
-        //Print the values from invDiag_A
-//        else
-//        {
-//            //clMemRAII<T> rData (control->queue(), invDiag_A.values);
-//            T* data = r_invDiag_A.clMapMem(CL_TRUE, CL_MAP_READ, invDiag_A.offset(), invDiag_A.n);
-
-//            for (int i = 0; i < invDiag_A.n; i++)
-//            {
-//                std::cout << "i = " << i << " " << data[i] << std::endl;
-//            }
-//            std::cout << std::endl;
-//        }
+        status = extract_diagonal<T, true>(invDiag_A, A, control);
+        OPENCL_V_THROW(status, "Invalid extract_diagonal kernel execution");
 
     }
 
     // apply preconditioner
-    void operator ()(const clsparseVectorPrivate* x,
-                     clsparseVectorPrivate* y,
+    void operator ()(const clsparse::array<T>& x,
+                     clsparse::array<T>& y,
                      clsparseControl control)
     {
         //element wise multiply y = x*invDiag_A;
         clsparseStatus status =
-                elementwise_transform<T, EW_MULTIPLY>(y, x, &invDiag_A, control);
-    }
-
-    ~DiagonalPreconditioner()
-    {
-        ::clReleaseMemObject(invDiag_A.values);
-        // return to init state;
-        clsparseInitVector(&invDiag_A);
+                elementwise_transform<T, EW_MULTIPLY>(y, x, invDiag_A, control);
+        OPENCL_V_THROW(status, "Diagonal operator()");
     }
 
 private:
     //inverse diagonal values of matrix A;
-    clsparseVectorPrivate invDiag_A;
+    clsparse::array<T> invDiag_A;
 };
 
 
@@ -114,8 +72,8 @@ public:
     {
     }
 
-    void operator()(const clsparseVectorPrivate* x,
-                    clsparseVectorPrivate* y,
+    void operator()(const clsparse::array<T>& x,
+                    clsparse::array<T>& y,
                     clsparseControl control)
     {
         (*diagonal)(x, y, control);

--- a/src/library/solvers/preconditioners/preconditioner.hpp
+++ b/src/library/solvers/preconditioners/preconditioner.hpp
@@ -3,6 +3,8 @@
 #define _CLSPARSE_PRECONDITIONER_HPP_
 
 #include "include/clSPARSE-private.hpp"
+#include "internal/data_types/clarray.hpp"
+
 //enum PRECONDITIONER
 //{
 //    VOID = 0,
@@ -65,8 +67,8 @@ template<typename T>
 class PreconditionerHandler
 {
 public:
-    virtual void operator()(const clsparseVectorPrivate* x,
-                       clsparseVectorPrivate* y,
+    virtual void operator()(const clsparse::array<T>& x,
+                       clsparse::array<T>& y,
                        clsparseControl control) = 0;
 
     virtual void notify(const clsparseCsrMatrixPrivate* pA,

--- a/src/library/solvers/preconditioners/preconditioner_utils.hpp
+++ b/src/library/solvers/preconditioners/preconditioner_utils.hpp
@@ -7,6 +7,11 @@
 #include "internal/kernel_wrap.hpp"
 #include "internal/clsparse_internal.hpp"
 
+#include "internal/data_types/clarray.hpp"
+
+#if !defined(min)
+#define min(x, y) std::min(x, y)
+#endif
 
 template<typename T, bool inverse = false>
 clsparseStatus
@@ -29,7 +34,7 @@ extract_diagonal(clsparseVectorPrivate* pDiag,
     assert (pA->n > 0);
     assert (pA->nnz > 0);
 
-    assert (pDiag->n == std::min(pA->n, pA->m));
+    assert (pDiag->n == min(pA->n, pA->m));
 
     cl_ulong wg_size = 256;
     cl_ulong size = pA->m;
@@ -92,4 +97,88 @@ extract_diagonal(clsparseVectorPrivate* pDiag,
     return clsparseSuccess;
 }
 
+
+template<typename T, bool inverse = false>
+clsparseStatus
+extract_diagonal(clsparse::array<T>& pDiag,
+                 const clsparseCsrMatrixPrivate* pA,
+                 clsparseControl control)
+{
+    if (!clsparseInitialized)
+    {
+        return clsparseNotInitialized;
+    }
+
+    //check opencl elements
+    if (control == nullptr)
+    {
+        return clsparseInvalidControlObject;
+    }
+
+    assert (pA->m > 0);
+    assert (pA->n > 0);
+    assert (pA->nnz > 0);
+
+    assert (pDiag.size() == min(pA->n, pA->m));
+
+    cl_ulong wg_size = 256;
+    cl_ulong size = pA->m;
+
+    cl_ulong nnz_per_row = pA->nnz_per_row();
+    cl_ulong wave_size = control->wavefront_size;
+    cl_ulong subwave_size = wave_size;
+
+    // adjust subwave_size according to nnz_per_row;
+    // each wavefron will be assigned to the row of the csr matrix
+    if(wave_size > 32)
+    {
+        //this apply only for devices with wavefront > 32 like AMD(64)
+        if (nnz_per_row < 64) {  subwave_size = 32;  }
+    }
+    if (nnz_per_row < 32) {  subwave_size = 16;  }
+    if (nnz_per_row < 16) {  subwave_size = 8;  }
+    if (nnz_per_row < 8)  {  subwave_size = 4;  }
+    if (nnz_per_row < 4)  {  subwave_size = 2;  }
+
+
+    std::string params = std::string()
+            + " -DSIZE_TYPE=" + OclTypeTraits<cl_ulong>::type
+            + " -DINDEX_TYPE=" + OclTypeTraits<cl_int>::type
+            + " -DVALUE_TYPE=" + OclTypeTraits<T>::type
+            + " -DWG_SIZE=" + std::to_string(wg_size)
+            + " -DWAVE_SIZE=" + std::to_string(wave_size)
+            + " -DSUBWAVE_SIZE=" + std::to_string(subwave_size);
+
+    if (inverse)
+        params.append(" -DOP_DIAG_INVERSE");
+
+
+    cl::Kernel kernel = KernelCache::get(control->queue, "matrix_utils",
+                                         "extract_diagonal", params);
+
+    KernelWrap kWrapper(kernel);
+
+    kWrapper << size
+             << pDiag.buffer()
+             << pA->rowOffsets
+             << pA->colIndices
+             << pA->values;
+
+    cl_uint predicted = subwave_size * size;
+
+    cl_uint global_work_size =
+            wg_size * ((predicted + wg_size - 1 ) / wg_size);
+    cl::NDRange local(wg_size);
+    //cl::NDRange global(predicted > local[0] ? predicted : local[0]);
+    cl::NDRange global(global_work_size > local[0] ? global_work_size : local[0]);
+
+    cl_int status = kWrapper.run(control, global, local);
+
+    if (status != CL_SUCCESS)
+    {
+        return clsparseInvalidKernelExecution;
+    }
+
+    return clsparseSuccess;
+}
 #endif //_CLSPARSE_PRECOND_UTILS_HPP_

--- a/src/library/solvers/preconditioners/void.hpp
+++ b/src/library/solvers/preconditioners/void.hpp
@@ -25,31 +25,17 @@ public:
 
     }
 
-    void operator() (const clsparseVectorPrivate* x,
-                     clsparseVectorPrivate* y,
+    void operator() (const clsparse::array<T>& x,
+                     clsparse::array<T>& y,
                      clsparseControl control)
     {
-        cl_ulong xSize = x->n - x->offset();
-        cl_ulong ySize = y->n - y->offset();
 
-        assert (xSize == ySize);
+        assert (x.size() == y.size());
 
         //void does nothing just copy x to y;
-#if (BUILD_CLVERSION < 200)
-        clEnqueueCopyBuffer(control->queue(), x->values, y->values,
-                            x->offset(), y->offset(),
-                            x->n * sizeof(T),
-                            control->event_wait_list.size(),
-                            &(control->event_wait_list.front())(),
-                            &control->event( )
-                            );
-#else
-        clEnqueueSVMMemcpy(control->queue(), CL_TRUE,
-                           y->values, x->values, x->n * sizeof(T),
-                           control->event_wait_list.size(),
-                           &(control->event_wait_list.front())(),
-                           &control->event( ));
-#endif
+
+        //deep copy;
+        y = x;
     }
 
 };
@@ -66,8 +52,8 @@ public:
 
     }
 
-    void operator ()(const clsparseVectorPrivate* x,
-                     clsparseVectorPrivate* y,
+    void operator ()(const clsparse::array<T>& x,
+                     clsparse::array<T>& y,
                      clsparseControl control)
     {
         (*void_precond)(x, y, control);

--- a/src/library/solvers/solver_control.cpp
+++ b/src/library/solvers/solver_control.cpp
@@ -43,7 +43,7 @@ clsparseReleaseSolverControl(clSParseSolverControl solverControl)
     solverControl->nIters = -1;
     solverControl->maxIters = -1;
     solverControl->initialResidual = -1;
-    solverControl->preconditioner = VOID;
+    solverControl->preconditioner = NOPRECOND;
 
     delete solverControl;
 

--- a/src/library/solvers/solver_control.hpp
+++ b/src/library/solvers/solver_control.hpp
@@ -1,4 +1,4 @@
-#pragma #once
+#pragma once
 #ifndef _CLSPARSE_SOLVER_CONTROL_HPP_
 #define _CLSPARSE_SOLVER_CONTROL_HPP_
 
@@ -20,7 +20,7 @@
 struct _solverControl
 {
 
-    _solverControl() : nIters(0), maxIters(0), preconditioner(VOID),
+    _solverControl() : nIters(0), maxIters(0), preconditioner(NOPRECOND),
         relativeTolerance(0.0), absoluteTolerance(0.0),
         initialResidual(0), currentResidual(0), printMode(QUIET)
     {
@@ -61,8 +61,8 @@ struct _solverControl
 
         switch(preconditioner)
         {
-        case VOID:
-            return "VOID";
+        case NOPRECOND:
+            return "No preconditioner";
         case DIAGONAL:
             return "Diagonal";
         }

--- a/src/library/spmv/clsparse_csrmv.hpp
+++ b/src/library/spmv/clsparse_csrmv.hpp
@@ -6,7 +6,7 @@
 #include "internal/clsparse_control.hpp"
 #include "spmv/csrmv_adaptive/csrmv_adaptive.hpp"
 #include "spmv/csrmv_vector/csrmv_vector.hpp"
-
+#include "internal/data_types/clarray.hpp"
 
 template <typename T>
 clsparseStatus
@@ -31,7 +31,39 @@ csrmv (const clsparseScalarPrivate *pAlpha,
         }
 
         // Call adaptive CSR kernels
-        return csrmv_adaptive<T>( *pAlpha, *pCsrMatx, *pX, *pBeta, *pY, control );
+        return csrmv_adaptive<T>( pAlpha, pCsrMatx, pX, pBeta, pY, control );
+    }
+
+}
+
+/*
+ * clsparse::array
+ */
+
+template <typename T>
+clsparseStatus
+csrmv (const clsparse::array<T>& pAlpha,
+       const clsparseCsrMatrixPrivate *pCsrMatx,
+       const clsparse::array<T>& pX,
+       const clsparse::array<T>& pBeta,
+       clsparse::array<T>& pY,
+       clsparseControl control)
+{
+
+    if( (pCsrMatx->rowBlocks == nullptr) && (pCsrMatx->rowBlockSize == 0) )
+    {
+        return csrmv_vector<T>(pAlpha, pCsrMatx, pX, pBeta, pY, control);
+    }
+    else
+    {
+        if( ( pCsrMatx->rowBlocks == nullptr ) || ( pCsrMatx->rowBlockSize == 0 ) )
+        {
+            // rowBlockSize varible is not zero but no pointer
+            return clsparseStructInvalid;
+        }
+
+        // Call adaptive CSR kernels
+        return csrmv_adaptive<T>( pAlpha, pCsrMatx, pX, pBeta, pY, control );
     }
 
 }

--- a/src/library/spmv/csrmv_adaptive/csrmv_adaptive.hpp
+++ b/src/library/spmv/csrmv_adaptive/csrmv_adaptive.hpp
@@ -6,13 +6,75 @@
 #include "internal/clsparse_validate.hpp"
 #include "internal/kernel_cache.hpp"
 #include "internal/kernel_wrap.hpp"
+#include "internal/data_types/clarray.hpp"
 
 template <typename T>
 clsparseStatus
-csrmv_adaptive( const clsparseScalarPrivate& pAlpha, const clsparseCsrMatrixPrivate& pCsrMatx,
-            const clsparseVectorPrivate& pX,
-            const clsparseScalarPrivate& pBeta,
-            clsparseVectorPrivate& pY,
+csrmv_adaptive( const clsparseScalarPrivate* pAlpha,
+                const clsparseCsrMatrixPrivate* pCsrMatx,
+                const clsparseVectorPrivate* pX,
+                const clsparseScalarPrivate* pBeta,
+                clsparseVectorPrivate* pY,
+                clsparseControl control )
+{
+    if(typeid(T) == typeid(cl_double))
+    {
+        return clsparseNotImplemented;
+    }
+
+    const cl_uint group_size = 256;
+
+    const std::string params = std::string( )
+    + " -DROWBITS=" + std::to_string( ROW_BITS )
+    + " -DWGBITS=" + std::to_string( WG_BITS )
+    + " -DBLOCKSIZE=" + std::to_string( BLKSIZE );
+#ifdef DOUBLE
+    buildFlags += " -DDOUBLE";
+#endif
+
+    cl::Kernel kernel = KernelCache::get( control->queue,
+                                          "csrmv_adaptive",
+                                          "csrmv_adaptive",
+                                          params );
+
+    KernelWrap kWrapper( kernel );
+
+    kWrapper << pCsrMatx->values
+        << pCsrMatx->colIndices << pCsrMatx->rowOffsets
+        << pX->values << pY->values
+        << pCsrMatx->rowBlocks
+        << pAlpha->value << pBeta->value;
+        //<< h_alpha << h_beta;
+
+    // if NVIDIA is used it does not allow to run the group size
+    // which is not a multiplication of group_size. Don't know if that
+    // have an impact on performance
+    cl_uint global_work_size = ( pCsrMatx->rowBlockSize - 1 ) * group_size;
+    cl::NDRange local( group_size );
+    cl::NDRange global( global_work_size > local[ 0 ] ? global_work_size : local[ 0 ] );
+
+    cl_int status = kWrapper.run( control, global, local );
+
+    if( status != CL_SUCCESS )
+    {
+        return clsparseInvalidKernelExecution;
+    }
+
+    return clsparseSuccess;
+}
+
+
+/*
+ * clsparse::array
+ */
+
+template <typename T>
+clsparseStatus
+csrmv_adaptive( const clsparse::array<T>& pAlpha,
+                const clsparseCsrMatrixPrivate* pCsrMatx,
+            const clsparse::array<T>& pX,
+            const clsparse::array<T>& pBeta,
+            clsparse::array<T>& pY,
             clsparseControl control )
 {
     if(typeid(T) == typeid(cl_double))
@@ -37,17 +99,17 @@ csrmv_adaptive( const clsparseScalarPrivate& pAlpha, const clsparseCsrMatrixPriv
 
     KernelWrap kWrapper( kernel );
 
-    kWrapper << pCsrMatx.values 
-        << pCsrMatx.colIndices << pCsrMatx.rowOffsets
-        << pX.values << pY.values 
-        << pCsrMatx.rowBlocks 
-        << pAlpha.value << pBeta.value;
+    kWrapper << pCsrMatx->values
+        << pCsrMatx->colIndices << pCsrMatx->rowOffsets
+        << pX.buffer() << pY.buffer()
+        << pCsrMatx->rowBlocks
+        << pAlpha.buffer() << pBeta.buffer();
         //<< h_alpha << h_beta;
 
     // if NVIDIA is used it does not allow to run the group size
     // which is not a multiplication of group_size. Don't know if that
     // have an impact on performance
-    cl_uint global_work_size = ( pCsrMatx.rowBlockSize - 1 ) * group_size;
+    cl_uint global_work_size = ( pCsrMatx->rowBlockSize - 1 ) * group_size;
     cl::NDRange local( group_size );
     cl::NDRange global( global_work_size > local[ 0 ] ? global_work_size : local[ 0 ] );
 

--- a/src/library/spmv/csrmv_vector/csrmv_vector.hpp
+++ b/src/library/spmv/csrmv_vector/csrmv_vector.hpp
@@ -4,6 +4,7 @@
 
 #include "internal/clsparse_validate.hpp"
 #include "internal/clsparse_internal.hpp"
+#include "internal/data_types/clarray.hpp"
 
 template<typename T>
 clsparseStatus
@@ -54,6 +55,84 @@ csrmv_vector(const clsparseScalarPrivate* pAlpha,
              << pX->values << pX->offset()
              << pBeta->value << pBeta->offset()
              << pY->values << pY->offset();
+
+    // subwave takes care of each row in matrix;
+    // predicted number of subwaves to be executed;
+    cl_uint predicted = subwave_size * pMatx->m;
+
+    // if NVIDIA is used it does not allow to run the group size
+    // which is not a multiplication of group_size. Don't know if that
+    // have an impact on performance
+    cl_uint global_work_size =
+            group_size* ((predicted + group_size - 1 ) / group_size);
+    cl::NDRange local(group_size);
+    //cl::NDRange global(predicted > local[0] ? predicted : local[0]);
+    cl::NDRange global(global_work_size > local[0] ? global_work_size : local[0]);
+
+    cl_int status = kWrapper.run(control, global, local);
+
+    if (status != CL_SUCCESS)
+    {
+        return clsparseInvalidKernelExecution;
+    }
+
+    return clsparseSuccess;
+}
+
+/*
+ * clsparse::array
+ */
+template<typename T>
+clsparseStatus
+csrmv_vector(const clsparse::array<T>& pAlpha,
+       const clsparseCsrMatrixPrivate* pMatx,
+       const clsparse::array<T>& pX,
+       const clsparse::array<T>& pBeta,
+       clsparse::array<T>& pY,
+       clsparseControl control)
+{
+    cl_uint nnz_per_row = pMatx->nnz_per_row(); //average nnz per row
+    cl_uint wave_size = control->wavefront_size;
+    cl_uint group_size = 256;    // 256 gives best performance!
+    cl_uint subwave_size = wave_size;
+
+    // adjust subwave_size according to nnz_per_row;
+    // each wavefron will be assigned to the row of the csr matrix
+    if(wave_size > 32)
+    {
+        //this apply only for devices with wavefront > 32 like AMD(64)
+        if (nnz_per_row < 64) {  subwave_size = 32;  }
+    }
+    if (nnz_per_row < 32) {  subwave_size = 16;  }
+    if (nnz_per_row < 16) {  subwave_size = 8;  }
+    if (nnz_per_row < 8)  {  subwave_size = 4;  }
+    if (nnz_per_row < 4)  {  subwave_size = 2;  }
+
+    const std::string params = std::string() +
+            "-DINDEX_TYPE=" + OclTypeTraits<cl_int>::type
+            + " -DVALUE_TYPE=" + OclTypeTraits<T>::type
+            + " -DSIZE_TYPE=" + OclTypeTraits<cl_ulong>::type
+            + " -DWG_SIZE=" + std::to_string(group_size)
+            + " -DWAVE_SIZE=" + std::to_string(wave_size)
+            + " -DSUBWAVE_SIZE=" + std::to_string(subwave_size);
+
+
+    cl::Kernel kernel = KernelCache::get(control->queue,
+                                         "csrmv_general",
+                                         "csrmv_general",
+                                         params);
+    KernelWrap kWrapper(kernel);
+
+    cl_ulong offset  = 0;
+
+    kWrapper << pMatx->m
+             << pAlpha.buffer() << offset
+             << pMatx->rowOffsets
+             << pMatx->colIndices
+             << pMatx->values
+             << pX.buffer() << offset
+             << pBeta.buffer() << offset
+             << pY.buffer() << offset;
 
     // subwave takes care of each row in matrix;
     // predicted number of subwaves to be executed;

--- a/src/tests/test_solver_cg.cpp
+++ b/src/tests/test_solver_cg.cpp
@@ -40,7 +40,7 @@ TEST (CG, float)
     ASSERT_EQ(CL_SUCCESS, status);
 
     clSParseSolverControl solver_control =
-            clsparseCreateSolverControl(1, VOID, 0.001, 1e-4);
+            clsparseCreateSolverControl(1, NOPRECOND, 0.001, 1e-4);
 
     ASSERT_NE(nullptr, solver_control);
 


### PR DESCRIPTION
I have adopted all algorithms to use new datatype. There are two versions of each algorithms depends on the data type. This branch was successfully compiled under Windows and Linux. The CG solver is fully using clsprase::array so it does not support OpenCL 2.0. The calls of blas1 and blas2 functions still follows the path with *Private structures. I see that if we adopt the clsparse::array to CL2.0 the *Private structures might be fully eliminated.

Main changes:
- all algorithms (dense blas1, blas2, spmv) are adopted to use clsparse::array data type.
- Matrix remains with the *Private structures due to matrix market functions which I don't want to touch yet.
- CG solver and preconditioners are based on clsparse::array
- simple iterator class for clsparse::array but I'm not using it and it was not tested. The iterator for range is tricky.

Bug:
While running xCGM benchmark gpuTImer throws out of range exception. Don't know why. One execution of xCGM can perform more than 1000 iterations to reach desired convergence. There are many calls for blas1 and blas2 functions per iteration. Too much events to collect? gpuTimer is commented from the code. 

FYI: When testing remember that CG is able to solve symmetric positive definite matrices like poisson, If the matrix will not have such properties the solver will diverge and the execution will be limited to max number of iterations in solver control. The second solver I will implement will be BiCGStab. This one will be able to solve other types of matrices arising in N-S equations.

Performance:
My tests comparing old and new implementation reveals that new one is faster ~10%:

Old:

```
========================StdDev ( 3 )========================
CPU xCGM[ 0 ]: Pruning 1 samples out of 20

==========================CPU xCGM==========================
          GiB/s:                    0.00260671
     Time (ns):                                2,265,041,736

```

New:

```
========================StdDev ( 3 )========================
CPU xCGM[ 0 ]: Pruning 1 samples out of 20

==========================CPU xCGM==========================
          GiB/s:                    0.00285602
     Time (ns):                                2,067,313,526

```
