### PR TITLE
Blas1 interface unification

### DIFF
--- a/samples/sample-axpy.cpp
+++ b/samples/sample-axpy.cpp
@@ -173,7 +173,7 @@ int main(int argc, char* argv[])
     }
     /** Step 4. Execute AXPY algorithm **/
 
-    status = cldenseSaxpy(&gpuY, &gpuAlpha, &gpuX, control);
+    status = cldenseSaxpy(&gpuY, &gpuAlpha, &gpuX, &gpuY, control);
 
     if (status != clsparseSuccess)
     {

--- a/src/benchmarks/cusparse-bench/src/mm_reader.cpp
+++ b/src/benchmarks/cusparse-bench/src/mm_reader.cpp
@@ -244,6 +244,8 @@ void MatrixMarketReader<FloatType>::MMGenerateCOOFromFile( FILE *infile )
     FloatType val;
     int ir, ic;
 
+    int rv;
+
     const int exp_zeroes = 0;
 
     for( int i = 0; i < nNZ; i++ )
@@ -251,9 +253,9 @@ void MatrixMarketReader<FloatType>::MMGenerateCOOFromFile( FILE *infile )
         if( mm_is_real( Typecode ) )
         {
             if( typeid( FloatType ) == typeid( float ) )
-                fscanf( infile, "%d %d %f\n", &ir, &ic, &val );
+              rv = fscanf( infile, "%d %d %f\n", &ir, &ic, &val );
             else if( typeid( FloatType ) == typeid( double ) )
-                fscanf( infile, "%d %d %lf\n", &ir, &ic, &val );
+              rv = fscanf( infile, "%d %d %lf\n", &ir, &ic, &val );
 
             if( exp_zeroes == 0 && val == 0 )
                 continue;
@@ -262,10 +264,10 @@ void MatrixMarketReader<FloatType>::MMGenerateCOOFromFile( FILE *infile )
         }
         else if( mm_is_integer( Typecode ) )
         {
-            if(typeid(FloatType) == typeid(float))
-                fscanf(infile, "%d %d %f\n", &ir, &ic, &val);
-            else if(typeid(FloatType) == typeid(double))
-                fscanf(infile, "%d %d %lf\n", &ir, &ic, &val);
+            if( typeid( FloatType ) == typeid( float ) )
+              rv = fscanf(infile, "%d %d %f\n", &ir, &ic, &val);
+            else if( typeid( FloatType ) == typeid( double ) )
+              rv = fscanf(infile, "%d %d %lf\n", &ir, &ic, &val);
 
             if( exp_zeroes == 0 && val == 0 )
                 continue;
@@ -275,7 +277,7 @@ void MatrixMarketReader<FloatType>::MMGenerateCOOFromFile( FILE *infile )
         }
         else if( mm_is_pattern( Typecode ) )
         {
-            fscanf( infile, "%d %d", &ir, &ic );
+            rv = fscanf( infile, "%d %d", &ir, &ic );
             val = static_cast<FloatType>( MAX_RAND_VAL * ( rand( ) / ( RAND_MAX + 1.0 ) ) );
 
             if( exp_zeroes == 0 && val == 0 )

--- a/src/include/clSPARSE.h
+++ b/src/include/clSPARSE.h
@@ -213,40 +213,46 @@ clsparseDCsrMatrixfromFile( clsparseCsrMatrix* csrMatx, const char* filePath, cl
 
     /* BLAS 1 routines for dense vector*/
 
-    /* SCALE y = alpha * y */
+    /* SCALE r = alpha * y */
 
     CLSPARSE_EXPORT clsparseStatus
-        cldenseSscale( cldenseVector* y,
+        cldenseSscale( cldenseVector* r,
+        const cldenseVector* y,
         const clsparseScalar* alpha,
         const clsparseControl control );
 
     CLSPARSE_EXPORT clsparseStatus
-        cldenseDscale( cldenseVector* y,
+        cldenseDscale( cldenseVector* r,
+        const cldenseVector* y,
         const clsparseScalar* alpha,
         const clsparseControl control );
 
-    /* AXPY: y = alpha*x + y*/
+    /* AXPY: r = alpha*x + y */
     CLSPARSE_EXPORT clsparseStatus
-        cldenseSaxpy( cldenseVector* y,
+        cldenseSaxpy( cldenseVector* r,
         const clsparseScalar* alpha, const cldenseVector* x,
+        const cldenseVector* y,
         const clsparseControl control );
 
     CLSPARSE_EXPORT clsparseStatus
-        cldenseDaxpy( cldenseVector* y,
+        cldenseDaxpy( cldenseVector* r,
         const clsparseScalar* alpha, const cldenseVector* x,
+        const cldenseVector* y,
         const clsparseControl control );
 
-    /* AXPY: y = alpha*x + beta*y*/
+    /* AXPY: r = alpha*x + beta*y */
     CLSPARSE_EXPORT clsparseStatus
-        cldenseSaxpby( cldenseVector* y,
+        cldenseSaxpby( cldenseVector* r,
         const clsparseScalar* alpha, const cldenseVector* x,
         const clsparseScalar* beta,
+        const cldenseVector* y,
         const clsparseControl control );
 
     CLSPARSE_EXPORT clsparseStatus
-        cldenseDaxpby( cldenseVector* y,
+        cldenseDaxpby( cldenseVector* r,
         const clsparseScalar* alpha, const cldenseVector* x,
         const clsparseScalar* beta,
+        const cldenseVector* y,
         const clsparseControl control );
 
     /* Reduce (sum) */

--- a/src/include/clSPARSE.h
+++ b/src/include/clSPARSE.h
@@ -302,6 +302,59 @@ clsparseDCsrMatrixfromFile( clsparseCsrMatrix* csrMatx, const char* filePath, cl
         const cldenseVector* y,
         const clsparseControl control );
 
+    /* elementwise operations for dense vectors +, -, *, / */
+
+    // +
+    CLSPARSE_EXPORT clsparseStatus
+        cldenseSadd( cldenseVector* r,
+        const cldenseVector* x,
+        const cldenseVector* y,
+        const clsparseControl control );
+
+    CLSPARSE_EXPORT clsparseStatus
+        cldenseDadd( cldenseVector* r,
+        const cldenseVector* x,
+        const cldenseVector* y,
+        const clsparseControl control );
+    // -
+    CLSPARSE_EXPORT clsparseStatus
+        cldenseSsub( cldenseVector* r,
+        const cldenseVector* x,
+        const cldenseVector* y,
+        const clsparseControl control );
+
+    CLSPARSE_EXPORT clsparseStatus
+        cldenseDsub( cldenseVector* r,
+        const cldenseVector* x,
+        const cldenseVector* y,
+        const clsparseControl control );
+
+    // *
+    CLSPARSE_EXPORT clsparseStatus
+        cldenseSmul( cldenseVector* r,
+        const cldenseVector* x,
+        const cldenseVector* y,
+        const clsparseControl control );
+
+    CLSPARSE_EXPORT clsparseStatus
+        cldenseDmul( cldenseVector* r,
+        const cldenseVector* x,
+        const cldenseVector* y,
+        const clsparseControl control );
+    // /
+    CLSPARSE_EXPORT clsparseStatus
+        cldenseSdiv( cldenseVector* r,
+        const cldenseVector* x,
+        const cldenseVector* y,
+        const clsparseControl control );
+
+    CLSPARSE_EXPORT clsparseStatus
+        cldenseDdiv( cldenseVector* r,
+        const cldenseVector* x,
+        const cldenseVector* y,
+        const clsparseControl control );
+
+
     // BLAS 2 routines
     // SpM-dV
     // y = \alpha * A * x + \beta * y

--- a/src/include/clSPARSE.h
+++ b/src/include/clSPARSE.h
@@ -216,15 +216,15 @@ clsparseDCsrMatrixfromFile( clsparseCsrMatrix* csrMatx, const char* filePath, cl
     /* SCALE r = alpha * y */
 
     CLSPARSE_EXPORT clsparseStatus
-        cldenseSscale( cldenseVector* r,
-        const cldenseVector* y,
+        cldenseSscale(cldenseVector* r,
         const clsparseScalar* alpha,
+        const cldenseVector* y,
         const clsparseControl control );
 
     CLSPARSE_EXPORT clsparseStatus
         cldenseDscale( cldenseVector* r,
-        const cldenseVector* y,
         const clsparseScalar* alpha,
+        const cldenseVector* y,
         const clsparseControl control );
 
     /* AXPY: r = alpha*x + y */

--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -120,6 +120,7 @@ set( clSPARSE.source.blas1
   blas1/reduce-operators.cpp
   blas1/cldense-nrm1.cpp
   blas1/cldense-nrm2.cpp
+  blas1/elementwise-transform.cpp
   blas1/elementwise-operators.cpp
 )
 

--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -158,6 +158,7 @@ set( clSPARSE.Headers.blas1
   blas1/reduce-operators.hpp
   blas1/commons.hpp
   blas1/cldense-dot.hpp
+  blas1/cldense-scale.hpp
   blas1/cldense-axpy.hpp
   blas1/cldense-axpby.hpp
   blas1/cldense-nrm1.hpp

--- a/src/library/blas1/cldense-axpby.cpp
+++ b/src/library/blas1/cldense-axpby.cpp
@@ -18,10 +18,11 @@
 #include "cldense-axpby.hpp"
 
 clsparseStatus
-cldenseSaxpby(cldenseVector *y,
+cldenseSaxpby(cldenseVector *r,
                const clsparseScalar *alpha,
                const cldenseVector *x,
                const clsparseScalar *beta,
+               const cldenseVector* y,
                const clsparseControl control)
 {
     if (!clsparseInitialized)
@@ -36,38 +37,25 @@ cldenseSaxpby(cldenseVector *y,
     }
 
 
-    cldenseVectorPrivate* pY = static_cast<cldenseVectorPrivate*> ( y );
-    const clsparseScalarPrivate* pAlpha = static_cast<const clsparseScalarPrivate*> ( alpha );
-    const cldenseVectorPrivate* pX = static_cast<const cldenseVectorPrivate*> ( x );
-    const clsparseScalarPrivate* pBeta = static_cast<const clsparseScalarPrivate*> ( beta );
+    clsparse::vector<cl_float> pR (control, r->values, r->num_values);
+    clsparse::vector<cl_float> pAlpha(control, alpha->value, 1);
+    clsparse::vector<cl_float> pX (control, x->values, x->num_values);
+    clsparse::vector<cl_float> pBeta(control, beta->value, 1);
+    clsparse::vector<cl_float> pY (control, y->values, y->num_values);
 
-    //is it necessary? Maybe run the kernel nevertheless those values?
-//    clMemRAII<cl_float> rAlpha (control->queue(), pAlpha->value);
-//    cl_float* fAlpha = rAlpha.clMapMem( CL_TRUE, CL_MAP_READ, pAlpha->offset(), 1);
-
-//    clMemRAII<cl_float> rBeta (control->queue(), pBeta->value);
-//    cl_float* fBeta = rBeta.clMapMem( CL_TRUE, CL_MAP_READ, pBeta->offset(), 1);
-
-    //nothing to do
-    //if (*fAlpha == 0) return clsparseSuccess;
-
-    cl_ulong y_size = pY->num_values - pY->offset();
-    cl_ulong x_size = pX->num_values - pX->offset();
-
-    cl_ulong size = (x_size >= y_size) ? y_size : x_size;
+    cl_ulong size = pR.size();
 
     if(size == 0) return clsparseSuccess;
 
-
-
-    return axpby<cl_float>(size, pY, pAlpha, pX, pBeta, control);
+    return axpby<cl_float>(pR, pAlpha, pX, pBeta, pY, control);
 }
 
 clsparseStatus
-cldenseDaxpby(cldenseVector *y,
+cldenseDaxpby(cldenseVector *r,
                const clsparseScalar *alpha,
                const cldenseVector *x,
                const clsparseScalar *beta,
+               const cldenseVector* y,
                const clsparseControl control)
 {
     if (!clsparseInitialized)
@@ -81,19 +69,51 @@ cldenseDaxpby(cldenseVector *y,
         return clsparseInvalidControlObject;
     }
 
-    cldenseVectorPrivate* pY = static_cast<cldenseVectorPrivate*> ( y );
-    const clsparseScalarPrivate* pAlpha = static_cast<const clsparseScalarPrivate*> ( alpha );
-    const cldenseVectorPrivate* pX = static_cast<const cldenseVectorPrivate*> ( x );
-    const clsparseScalarPrivate* pBeta = static_cast<const clsparseScalarPrivate*> ( beta );
+    clsparse::vector<cl_double> pR (control, r->values, r->num_values);
+    clsparse::vector<cl_double> pAlpha(control, alpha->value, 1);
+    clsparse::vector<cl_double> pX (control, x->values, x->num_values);
+    clsparse::vector<cl_double> pBeta(control, beta->value, 1);
+    clsparse::vector<cl_double> pY (control, y->values, y->num_values);
 
-
-    cl_ulong y_size = pY->num_values - pY->offset();
-    cl_ulong x_size = pX->num_values - pX->offset();
-
-    cl_ulong size = (x_size >= y_size) ? y_size : x_size;
+    cl_ulong size = pR.size();
 
     if(size == 0) return clsparseSuccess;
 
+    /*TODO: Is it worth to check alpha and beta to call
+     * axpy, scale or just copy? It might matter for very large vectors
+     *
+     * Example of how the code might look like
+     *
+     * cl_double _alpha = pAlpha[0];
+     * cl_double _beta =  pBeta[0];
+     *
+     * cl_double zero = 0.0;
+     *
+     * if (_alpha == 0.0)
+     * {
+     *      if (_beta == 0.0)
+     *      {
+     *          pR.fill(control, zero);
+     *          return clsparseSuccess;
+     *      }
+     *      else
+     *      {
+     *          return scale<cl_double>(pR, pBeta, pY);
+     *      }
+     * }
+     * else if ( _beta == 0.0 )
+     * {
+     *      if ( _alpha == 0.0 )
+     *      {
+     *          pR.fill(control, zero);
+     *          return clsparseSuccess;
+     *      }
+     *      else
+     *      {
+     *          return scale<cl_double>(pR, pAlpha, pX);
+     *      }
+     * }
+     */
 
-    return axpby<cl_double>(size, pY, pAlpha, pX, pBeta, control);
+    return axpby(pR, pAlpha, pX, pBeta, pY, control);
 }

--- a/src/library/blas1/cldense-axpby.hpp
+++ b/src/library/blas1/cldense-axpby.hpp
@@ -27,71 +27,16 @@
 
 #include "internal/data-types/clvector.hpp"
 
-template<typename T, ElementWiseOperator OP = EW_PLUS>
-clsparseStatus
-axpby(cl_ulong size,
-      cldenseVectorPrivate* pY,
-      const clsparseScalarPrivate* pAlpha,
-      const cldenseVectorPrivate* pX,
-      const clsparseScalarPrivate* pBeta,
-      const clsparseControl control)
-{
-
-    const int group_size = 256; // this or higher? control->max_wg_size?
-
-    const std::string params = std::string()
-            + " -DSIZE_TYPE=" + OclTypeTraits<cl_ulong>::type
-            + " -DVALUE_TYPE=" + OclTypeTraits<T>::type
-            + " -DWG_SIZE=" + std::to_string( group_size )
-            + " -D" + ElementWiseOperatorTrait<OP>::operation;
-
-    cl::Kernel kernel = KernelCache::get(control->queue, "blas1", "axpby",
-                                         params);
-
-    KernelWrap kWrapper(kernel);
-
-    kWrapper << size
-             << pY->values
-             << pY->offset()
-             << pAlpha->value
-             << pAlpha->offset()
-             << pX->values
-             << pX->offset()
-             << pBeta->value
-             << pBeta->offset()
-             << pY->values
-             << pY->offset();
-
-    int blocksNum = (size + group_size - 1) / group_size;
-    int globalSize = blocksNum * group_size;
-
-    cl::NDRange local(group_size);
-    cl::NDRange global (globalSize);
-
-    cl_int status = kWrapper.run(control, global, local);
-
-    if (status != CL_SUCCESS)
-    {
-        return clsparseInvalidKernelExecution;
-    }
-
-    return clsparseSuccess;
-}
-
-
-//version for clsparse::array
-
-// pY is a result container;
-// y = alpha * x + beta * z;
-// if z == y we have standard axpby; should we adopt the clSPARSE.h to this interface?
+// r = alpha * x + beta * y;
+// if r == y we have standard axpby;
 
 template<typename T, ElementWiseOperator OP = EW_PLUS>
 clsparseStatus
-axpby(clsparse::array_base<T>& pY,
+axpby(clsparse::array_base<T>& pR,
       const clsparse::array_base<T>& pAlpha,
       const clsparse::array_base<T>& pX,
       const clsparse::array_base<T>& pBeta,
-      const clsparse::array_base<T>& pZ,
+      const clsparse::array_base<T>& pY,
       const clsparseControl control)
 {
 
@@ -108,13 +53,13 @@ axpby(clsparse::array_base<T>& pY,
 
     KernelWrap kWrapper(kernel);
 
-    cl_ulong size = pY.size();
+    cl_ulong size = pR.size();
 
     //clsparse do not support offset;
     cl_ulong offset = 0;
 
     kWrapper << size
-             << pY.data()
+             << pR.data()
              << offset
              << pAlpha.data()
              << offset
@@ -122,7 +67,7 @@ axpby(clsparse::array_base<T>& pY,
              << offset
              << pBeta.data()
              << offset
-             << pZ.data()
+             << pY.data()
              << offset;
 
     int blocksNum = (size + group_size - 1) / group_size;

--- a/src/library/blas1/cldense-axpy.hpp
+++ b/src/library/blas1/cldense-axpy.hpp
@@ -28,58 +28,10 @@
 
 template<typename T, ElementWiseOperator OP = EW_PLUS>
 clsparseStatus
-axpy(cl_ulong size,
-     cldenseVectorPrivate* pY,
-     const clsparseScalarPrivate* pAlpha,
-     const cldenseVectorPrivate* pX,
-     const clsparseControl control)
-{
-    const int group_size = 256; // this or higher? control->max_wg_size?
-
-    const std::string params = std::string()
-            + " -DSIZE_TYPE=" + OclTypeTraits<cl_ulong>::type
-            + " -DVALUE_TYPE=" + OclTypeTraits<T>::type
-            + " -DWG_SIZE=" + std::to_string( group_size )
-            + " -D" + ElementWiseOperatorTrait<OP>::operation;
-
-    cl::Kernel kernel = KernelCache::get(control->queue, "blas1", "axpy",
-                                         params);
-
-    KernelWrap kWrapper(kernel);
-
-    kWrapper << size
-             << pY->values
-             << pY->offset()
-             << pAlpha->value
-             << pAlpha->offset()
-             << pX->values
-             << pX->offset()
-             << pY->values
-             << pY->offset();
-
-    int blocksNum = (size + group_size - 1) / group_size;
-    int globalSize = blocksNum * group_size;
-
-    cl::NDRange local(group_size);
-    cl::NDRange global (globalSize);
-
-    cl_int status = kWrapper.run(control, global, local);
-
-    if (status != CL_SUCCESS)
-    {
-        return clsparseInvalidKernelExecution;
-    }
-
-    return clsparseSuccess;
-}
-
-
-template<typename T, ElementWiseOperator OP = EW_PLUS>
-clsparseStatus
-axpy(clsparse::array_base<T>& pY,
+axpy(clsparse::array_base<T>& pR,
      const clsparse::array_base<T>& pAlpha,
      const clsparse::array_base<T>& pX,
-     const clsparse::array_base<T>& pZ,
+     const clsparse::array_base<T>& pY,
      const clsparseControl control)
 {
     const int group_size = 256; // this or higher? control->max_wg_size?
@@ -95,17 +47,17 @@ axpy(clsparse::array_base<T>& pY,
 
     KernelWrap kWrapper(kernel);
 
-    cl_ulong size = pY.size();
+    cl_ulong size = pR.size();
     cl_ulong offset = 0;
 
     kWrapper << size
-             << pY.data()
+             << pR.data()
              << offset
              << pAlpha.data()
              << offset
              << pX.data()
              << offset
-             << pZ.data()
+             << pY.data()
              << offset;
 
     int blocksNum = (size + group_size - 1) / group_size;

--- a/src/library/blas1/cldense-scale.hpp
+++ b/src/library/blas1/cldense-scale.hpp
@@ -1,0 +1,76 @@
+/* ************************************************************************
+ * Copyright 2015 Vratis, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************************************************************ */
+
+#pragma once
+#ifndef _CLSPARSE_SCALE_HPP_
+#define _CLSPARSE_SCALE_HPP_
+
+#include "include/clSPARSE-private.hpp"
+#include "internal/kernel-cache.hpp"
+#include "internal/kernel-wrap.hpp"
+#include "internal/clsparse-internal.hpp"
+
+#include "internal/data-types/clvector.hpp"
+
+//TODO:: add offset to the scale kernel
+template <typename T>
+clsparseStatus
+scale( clsparse::array_base<T>& pResult,
+       const clsparse::array_base<T>& pAlpha,
+       const clsparse::array_base<T>& pVector,
+       clsparseControl control)
+{
+    const int group_size = 256;
+    //const int group_size = control->max_wg_size;
+
+    const std::string params = std::string()
+            + " -DSIZE_TYPE=" + OclTypeTraits<cl_ulong>::type
+            + " -DVALUE_TYPE="+ OclTypeTraits<T>::type
+            + " -DWG_SIZE=" + std::to_string(group_size);
+
+    cl::Kernel kernel = KernelCache::get(control->queue,
+                                         "blas1", "scale",
+                                         params);
+    KernelWrap kWrapper(kernel);
+
+    cl_ulong size = pResult.size();
+    cl_ulong offset = 0;
+
+    kWrapper << size
+             << pResult.data()
+             << offset
+             << pVector.data()
+             << offset
+             << pAlpha.data()
+             << offset;
+
+    int blocksNum = (size + group_size - 1) / group_size;
+    int globalSize = blocksNum * group_size;
+
+    cl::NDRange local(group_size);
+    cl::NDRange global (globalSize);
+
+    cl_int status = kWrapper.run(control, global, local);
+
+    if (status != CL_SUCCESS)
+    {
+        return clsparseInvalidKernelExecution;
+    }
+
+    return clsparseSuccess;
+}
+
+#endif //_CLSPARSE_SCALE_HPP_

--- a/src/library/blas1/elementwise-transform.cpp
+++ b/src/library/blas1/elementwise-transform.cpp
@@ -1,0 +1,124 @@
+/* ************************************************************************
+ * Copyright 2015 Vratis, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************************************************************ */
+#include "include/clSPARSE-private.hpp"
+#include "elementwise-transform.hpp"
+
+// +
+clsparseStatus
+cldenseSadd( cldenseVector* r,
+             const cldenseVector* x,
+             const cldenseVector* y,
+             const clsparseControl control )
+{
+    cldenseVectorPrivate *pR = static_cast<cldenseVectorPrivate*> ( r );
+    const cldenseVectorPrivate *pX = static_cast<const cldenseVectorPrivate*> ( x );
+    const cldenseVectorPrivate *pY = static_cast<const cldenseVectorPrivate*> ( y );
+
+    return elementwise_transform<cl_float, EW_PLUS> (pR, pX, pY, control);
+}
+
+clsparseStatus
+cldenseDadd( cldenseVector* r,
+             const cldenseVector* x,
+             const cldenseVector* y,
+             const clsparseControl control )
+{
+    cldenseVectorPrivate *pR = static_cast<cldenseVectorPrivate*> ( r );
+    const cldenseVectorPrivate *pX = static_cast<const cldenseVectorPrivate*> ( x );
+    const cldenseVectorPrivate *pY = static_cast<const cldenseVectorPrivate*> ( y );
+
+    return elementwise_transform<cl_double, EW_PLUS> (pR, pX, pY, control);
+}
+
+// -
+clsparseStatus
+cldenseSsub( cldenseVector* r,
+             const cldenseVector* x,
+             const cldenseVector* y,
+             const clsparseControl control )
+{
+    cldenseVectorPrivate *pR = static_cast<cldenseVectorPrivate*> ( r );
+    const cldenseVectorPrivate *pX = static_cast<const cldenseVectorPrivate*> ( x );
+    const cldenseVectorPrivate *pY = static_cast<const cldenseVectorPrivate*> ( y );
+
+    return elementwise_transform<cl_float, EW_MINUS> (pR, pX, pY, control);
+}
+
+clsparseStatus
+cldenseDsub( cldenseVector* r,
+             const cldenseVector* x,
+             const cldenseVector* y,
+             const clsparseControl control )
+{
+    cldenseVectorPrivate *pR = static_cast<cldenseVectorPrivate*> ( r );
+    const cldenseVectorPrivate *pX = static_cast<const cldenseVectorPrivate*> ( x );
+    const cldenseVectorPrivate *pY = static_cast<const cldenseVectorPrivate*> ( y );
+    return elementwise_transform<cl_double, EW_MINUS> (pR, pX, pY, control);
+}
+
+// *
+clsparseStatus
+cldenseSmul( cldenseVector* r,
+             const cldenseVector* x,
+             const cldenseVector* y,
+             const clsparseControl control )
+{
+    cldenseVectorPrivate *pR = static_cast<cldenseVectorPrivate*> ( r );
+    const cldenseVectorPrivate *pX = static_cast<const cldenseVectorPrivate*> ( x );
+    const cldenseVectorPrivate *pY = static_cast<const cldenseVectorPrivate*> ( y );
+
+    return elementwise_transform<cl_float, EW_MULTIPLY> (pR, pX, pY, control);
+}
+
+clsparseStatus
+cldenseDmul( cldenseVector* r,
+             const cldenseVector* x,
+             const cldenseVector* y,
+             const clsparseControl control )
+{
+    cldenseVectorPrivate *pR = static_cast<cldenseVectorPrivate*> ( r );
+    const cldenseVectorPrivate *pX = static_cast<const cldenseVectorPrivate*> ( x );
+    const cldenseVectorPrivate *pY = static_cast<const cldenseVectorPrivate*> ( y );
+
+    return elementwise_transform<cl_double, EW_MULTIPLY> (pR, pX, pY, control);
+}
+
+// "/" (div)
+clsparseStatus
+cldenseSdiv( cldenseVector* r,
+             const cldenseVector* x,
+             const cldenseVector* y,
+             const clsparseControl control )
+{
+    cldenseVectorPrivate *pR = static_cast<cldenseVectorPrivate*> ( r );
+    const cldenseVectorPrivate *pX = static_cast<const cldenseVectorPrivate*> ( x );
+    const cldenseVectorPrivate *pY = static_cast<const cldenseVectorPrivate*> ( y );
+
+    return elementwise_transform<cl_float, EW_DIV> (pR, pX, pY, control);
+}
+
+clsparseStatus
+cldenseDdiv( cldenseVector* r,
+             const cldenseVector* x,
+             const cldenseVector* y,
+             const clsparseControl control )
+{
+    cldenseVectorPrivate *pR = static_cast<cldenseVectorPrivate*> ( r );
+    const cldenseVectorPrivate *pX = static_cast<const cldenseVectorPrivate*> ( x );
+    const cldenseVectorPrivate *pY = static_cast<const cldenseVectorPrivate*> ( y );
+
+    return elementwise_transform<cl_double, EW_DIV> (pR, pX, pY, control);
+}

--- a/src/library/blas1/elementwise-transform.hpp
+++ b/src/library/blas1/elementwise-transform.hpp
@@ -40,7 +40,7 @@ clsparseStatus
 elementwise_transform(cldenseVectorPrivate* r,
                       const cldenseVectorPrivate* x,
                       const cldenseVectorPrivate* y,
-                      clsparseControl control)
+                      const clsparseControl control)
 {
     if (!clsparseInitialized)
     {
@@ -54,7 +54,7 @@ elementwise_transform(cldenseVectorPrivate* r,
     }
 
     assert(x->num_values == y->num_values);
-    assert(x->num_values== r->num_values);
+    assert(x->num_values == r->num_values);
 
     cl_ulong size = x->num_values;
     cl_uint wg_size = 256;
@@ -95,7 +95,7 @@ clsparseStatus
 elementwise_transform(clsparse::array_base<T>& r,
                       const clsparse::array_base<T>& x,
                       const clsparse::array_base<T>& y,
-                      clsparseControl control)
+                      const clsparseControl control)
 {
     if (!clsparseInitialized)
     {

--- a/src/library/include/clSPARSE-1x.hpp
+++ b/src/library/include/clSPARSE-1x.hpp
@@ -100,14 +100,19 @@ public:
          }
     }
 
-    pType* clMapMem( cl_bool clBlocking, const cl_map_flags clFlags, const size_t clOff, const size_t clSize )
+    pType* clMapMem( cl_bool clBlocking, const cl_map_flags clFlags, const size_t clOff, const size_t clSize, cl_int *clStatus = nullptr)
     {
         // Right now, we don't support returning an event to wait on
         clBlocking = CL_TRUE;
-        cl_int clStatus = 0;
+        cl_int _clStatus = 0;
 
         clMem = static_cast< pType* >( ::clEnqueueMapBuffer( clQueue, clBuff, clBlocking, clFlags, clOff,
-            clSize * sizeof( pType ), 0, NULL, NULL, &clStatus ) );
+            clSize * sizeof( pType ), 0, NULL, NULL, &_clStatus ) );
+
+        if (clStatus != nullptr)
+        {
+            *clStatus = _clStatus;
+        }
 
         return clMem;
     }

--- a/src/library/include/clSPARSE-2x.hpp
+++ b/src/library/include/clSPARSE-2x.hpp
@@ -93,12 +93,17 @@ public:
         ::clRetainCommandQueue( clQueue );
     }
 
-    pType* clMapMem( cl_bool clBlocking, const cl_map_flags clFlags, const size_t clOff, const size_t clSize )
+    pType* clMapMem( cl_bool clBlocking, const cl_map_flags clFlags, const size_t clOff, const size_t clSize, cl_int *clStatus = nullptr)
     {
         // Right now, we don't support returning an event to wait on
         clBlocking = CL_TRUE;
 
-        cl_int clStatus = ::clEnqueueSVMMap( clQueue, clBlocking, clFlags, clMem, clSize * sizeof( pType ), 0, NULL, NULL );
+        cl_int _clStatus = ::clEnqueueSVMMap( clQueue, clBlocking, clFlags,
+                                              clMem, clSize * sizeof( pType ), 0, NULL, NULL );
+        if (clStatus != nullptr)
+        {
+            *clStatus = _clStatus;
+        }
 
         return clMem;
     }

--- a/src/library/internal/computeRowBlocks.hpp
+++ b/src/library/internal/computeRowBlocks.hpp
@@ -88,7 +88,8 @@ static inline rowBlockType numThreadsForReduction(rowBlockType num_rows)
 
 //  rowBlockType is currently instantiated as ulong
 template< typename rowBlockType >
-void ComputeRowBlocks( rowBlockType* rowBlocks, size_t& rowBlockSize, const int* rowDelimiters, int nRows, int blkSize, int blkMultiplier, int rows_for_vector, bool allocate_row_blocks = true )
+void ComputeRowBlocks( rowBlockType* rowBlocks, size_t& rowBlockSize, const int* rowDelimiters,
+                       int nRows, int blkSize, int blkMultiplier, int rows_for_vector, bool allocate_row_blocks = true )
 {
     rowBlockType* rowBlocksBase;
     int total_row_blocks = 1; // Start at one because of rowBlock[0]

--- a/src/library/io/mm-reader.cpp
+++ b/src/library/io/mm-reader.cpp
@@ -257,14 +257,17 @@ void MatrixMarketReader<FloatType>::MMGenerateCOOFromFile( FILE *infile )
 
     const int exp_zeroes = 0;
 
+    //silence warnings from fscanf (-Wunused-result)
+    int rv = 0;
+
     for( int i = 0; i < nNZ; i++ )
     {
         if( mm_is_real( Typecode ) )
         {
             if( typeid( FloatType ) == typeid( float ) )
-                fscanf( infile, "%d %d %f\n", &ir, &ic, (float*)( &val ) );
+              rv = fscanf( infile, "%d %d %f\n", &ir, &ic, (float*)( &val ) );
             else if( typeid( FloatType ) == typeid( double ) )
-                fscanf( infile, "%d %d %lf\n", &ir, &ic, (double*)( &val ) );
+              rv = fscanf( infile, "%d %d %lf\n", &ir, &ic, (double*)( &val ) );
 
             if( exp_zeroes == 0 && val == 0 )
                 continue;
@@ -274,9 +277,9 @@ void MatrixMarketReader<FloatType>::MMGenerateCOOFromFile( FILE *infile )
         else if( mm_is_integer( Typecode ) )
         {
             if(typeid(FloatType) == typeid(float))
-                fscanf(infile, "%d %d %f\n", &ir, &ic, (float*)( &val ) );
+               rv = fscanf(infile, "%d %d %f\n", &ir, &ic, (float*)( &val ) );
             else if(typeid(FloatType) == typeid(double))
-                fscanf(infile, "%d %d %lf\n", &ir, &ic, (double*)( &val ) );
+               rv = fscanf(infile, "%d %d %lf\n", &ir, &ic, (double*)( &val ) );
 
             if( exp_zeroes == 0 && val == 0 )
                 continue;
@@ -286,7 +289,7 @@ void MatrixMarketReader<FloatType>::MMGenerateCOOFromFile( FILE *infile )
         }
         else if( mm_is_pattern( Typecode ) )
         {
-            fscanf( infile, "%d %d", &ir, &ic );
+            rv = fscanf( infile, "%d %d", &ir, &ic );
             val = static_cast<FloatType>( MAX_RAND_VAL * ( rand( ) / ( RAND_MAX + 1.0 ) ) );
 
             if( exp_zeroes == 0 && val == 0 )

--- a/src/library/io/mm-reader.cpp
+++ b/src/library/io/mm-reader.cpp
@@ -597,7 +597,17 @@ clsparseSCsrMatrixfromFile(clsparseCsrMatrix* csrMatx, const char* filePath, cls
     {
         clMemRAII< cl_ulong > rRowBlocks( control->queue( ), pCsrMatx->rowBlocks );
         ComputeRowBlocks( (cl_ulong*)NULL, pCsrMatx->rowBlockSize, iCsrRowOffsets, pCsrMatx->num_rows, BLKSIZE, BLOCK_MULTIPLIER, ROWS_FOR_VECTOR, false );
-        cl_ulong* ulCsrRowBlocks = rRowBlocks.clMapMem( CL_TRUE, CL_MAP_WRITE_INVALIDATE_REGION, pCsrMatx->rowBlocksOffset( ), pCsrMatx->rowBlockSize );
+
+        // matrix SMALL/Reuters/Reuters911.mtx throws here segfault
+        // due to wrong estimation of rowBlockSize in function clsparseCsrMetaSize.
+        cl_int mapStatus = 0;
+        cl_ulong* ulCsrRowBlocks = rRowBlocks.clMapMem( CL_TRUE, CL_MAP_WRITE_INVALIDATE_REGION, pCsrMatx->rowBlocksOffset( ), pCsrMatx->rowBlockSize, &mapStatus );
+
+        if (mapStatus != CL_SUCCESS)
+        {
+            std::cerr << "Error: Row block estimation too low, invalid value returned from mapping" << std::endl;
+            return clsparseInvalidValue;
+        }
 
         ComputeRowBlocks( ulCsrRowBlocks, pCsrMatx->rowBlockSize, iCsrRowOffsets, pCsrMatx->num_rows, BLKSIZE, BLOCK_MULTIPLIER, ROWS_FOR_VECTOR, true );
     }

--- a/src/library/kernels/blas1.cl
+++ b/src/library/kernels/blas1.cl
@@ -106,18 +106,20 @@ void axpby(const SIZE_TYPE size,
 R"(
 __kernel
 __attribute__((reqd_work_group_size(WG_SIZE, 1, 1)))
-void scale (const SIZE_TYPE pYSize,
-            __global VALUE_TYPE* pY,
+void scale (const SIZE_TYPE pRSize,
+            __global VALUE_TYPE* pR,
+            const SIZE_TYPE pROffset,
+            __global const VALUE_TYPE* pY,
             const SIZE_TYPE pYOffset,
              __global const VALUE_TYPE* pAlpha,
             const SIZE_TYPE pAlphaOffset)
 {
     const int i = get_global_id(0);
 
-    if (i >= pYSize) return;
+    if (i >= pRSize) return;
 
     const VALUE_TYPE alpha = *(pAlpha + pAlphaOffset);
 
-    pY[i + pYOffset] = pY[i + pYOffset]* alpha;
+    pR[i + pROffset] = pY[i + pYOffset]* alpha;
 }
 )"

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -100,6 +100,7 @@ set( headers
   resources/clsparse_environment.h
   resources/matrix_utils.h
   resources/csr_matrix_environment.h
+  resources/blas1_environment.h
   #resources/uBLAS-linalg/ublas_pcg.hpp
   #resources/uBLAS-linalg/precond.hpp
   #resources/uBLAS-linalg/cholesky.hpp

--- a/src/tests/resources/blas1_environment.h
+++ b/src/tests/resources/blas1_environment.h
@@ -1,0 +1,43 @@
+/* ************************************************************************
+ * Copyright 2015 Vratis, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************************************************************ */
+
+#pragma once
+#ifndef _BLAS1_ENVIRONMENT_H_
+#define _BLAS1_ENVIRONMENT_H_
+
+#include <gtest/gtest.h>
+
+class Blas1Environment : public ::testing::Environment
+{
+public:
+
+    Blas1Environment(double alpha, double beta)
+    {
+        this->alpha = alpha;
+        this->beta = beta;
+    }
+
+    void SetUp( )  {  }
+
+    void TearDown( )  {  }
+
+    static double alpha;
+    static double beta;
+};
+
+
+#endif //_BLAS1_ENVIRONMENT_H_
+

--- a/src/tests/test-blas1.cpp
+++ b/src/tests/test-blas1.cpp
@@ -365,6 +365,163 @@ public:
 
     }
 
+    void test_add()
+    {
+        clsparseStatus status;
+
+        if (typeid(T) == typeid(cl_float))
+        {
+            status = cldenseSadd(&gY, &gX, &gY, CLSE::control);
+        }
+        else if ( typeid(T) == typeid(cl_double) )
+        {
+            status = cldenseDadd(&gY, &gX, &gY, CLSE::control);
+        }
+
+        ASSERT_EQ(clsparseSuccess, status);
+
+        hY = hX + hY;
+
+        cl_int cl_status;
+        T* host_result = (T*) ::clEnqueueMapBuffer(CLSE::queue, gY.values,
+                                              CL_TRUE, CL_MAP_READ,
+                                              0, gY.num_values * sizeof(T),
+                                              0, nullptr, nullptr, &cl_status);
+        ASSERT_EQ (CL_SUCCESS, cl_status);
+
+        // change it to some compare template functions
+        if ( typeid(T) == typeid(cl_float) )
+            for(int i = 0; i < hY.size(); i++)
+                ASSERT_NEAR (hY[i], host_result[i], 1e-7);
+
+        if ( typeid(T) == typeid(cl_double) )
+            for(int i = 0; i < hY.size(); i++)
+                ASSERT_NEAR (hY[i], host_result[i], 1e-14);
+
+        cl_status = ::clEnqueueUnmapMemObject(CLSE::queue, gY.values,
+                                              host_result, 0, nullptr, nullptr);
+        ASSERT_EQ (CL_SUCCESS, cl_status);
+    }
+
+    void test_sub()
+    {
+        clsparseStatus status;
+
+        if (typeid(T) == typeid(cl_float))
+        {
+            status = cldenseSsub(&gY, &gX, &gY, CLSE::control);
+        }
+        else if ( typeid(T) == typeid(cl_double) )
+        {
+            status = cldenseDsub(&gY, &gX, &gY, CLSE::control);
+        }
+
+        ASSERT_EQ(clsparseSuccess, status);
+
+        hY = hX - hY;
+
+        cl_int cl_status;
+        T* host_result = (T*) ::clEnqueueMapBuffer(CLSE::queue, gY.values,
+                                              CL_TRUE, CL_MAP_READ,
+                                              0, gY.num_values * sizeof(T),
+                                              0, nullptr, nullptr, &cl_status);
+        ASSERT_EQ (CL_SUCCESS, cl_status);
+
+        // change it to some compare template functions
+        if ( typeid(T) == typeid(cl_float) )
+            for(int i = 0; i < hY.size(); i++)
+                ASSERT_NEAR (hY[i], host_result[i], 1e-7);
+
+        if ( typeid(T) == typeid(cl_double) )
+            for(int i = 0; i < hY.size(); i++)
+                ASSERT_NEAR (hY[i], host_result[i], 1e-14);
+
+        cl_status = ::clEnqueueUnmapMemObject(CLSE::queue, gY.values,
+                                              host_result, 0, nullptr, nullptr);
+        ASSERT_EQ (CL_SUCCESS, cl_status);
+
+
+
+    }
+
+    void test_mul()
+    {
+        clsparseStatus status;
+
+        if (typeid(T) == typeid(cl_float))
+        {
+            status = cldenseSmul(&gY, &gX, &gY, CLSE::control);
+        }
+        else if ( typeid(T) == typeid(cl_double) )
+        {
+            status = cldenseDmul(&gY, &gX, &gY, CLSE::control);
+        }
+
+        ASSERT_EQ(clsparseSuccess, status);
+
+        hY = uBLAS::element_prod(hX, hY);
+
+        cl_int cl_status;
+        T* host_result = (T*) ::clEnqueueMapBuffer(CLSE::queue, gY.values,
+                                              CL_TRUE, CL_MAP_READ,
+                                              0, gY.num_values * sizeof(T),
+                                              0, nullptr, nullptr, &cl_status);
+        ASSERT_EQ (CL_SUCCESS, cl_status);
+
+        // change it to some compare template functions
+        if ( typeid(T) == typeid(cl_float) )
+            for(int i = 0; i < hY.size(); i++)
+                ASSERT_NEAR (hY[i], host_result[i], 1e-7);
+
+        if ( typeid(T) == typeid(cl_double) )
+            for(int i = 0; i < hY.size(); i++)
+                ASSERT_NEAR (hY[i], host_result[i], 1e-14);
+
+        cl_status = ::clEnqueueUnmapMemObject(CLSE::queue, gY.values,
+                                              host_result, 0, nullptr, nullptr);
+        ASSERT_EQ (CL_SUCCESS, cl_status);
+
+    }
+
+    void test_div()
+    {
+        clsparseStatus status;
+
+        if (typeid(T) == typeid(cl_float))
+        {
+            status = cldenseSdiv(&gY, &gX, &gY, CLSE::control);
+        }
+        else if ( typeid(T) == typeid(cl_double) )
+        {
+            status = cldenseDdiv(&gY, &gX, &gY, CLSE::control);
+        }
+
+        ASSERT_EQ(clsparseSuccess, status);
+
+        hY = uBLAS::element_div(hX, hY);
+
+        cl_int cl_status;
+        T* host_result = (T*) ::clEnqueueMapBuffer(CLSE::queue, gY.values,
+                                              CL_TRUE, CL_MAP_READ,
+                                              0, gY.num_values * sizeof(T),
+                                              0, nullptr, nullptr, &cl_status);
+        ASSERT_EQ (CL_SUCCESS, cl_status);
+
+        // change it to some compare template functions
+        if ( typeid(T) == typeid(cl_float) )
+            for(int i = 0; i < hY.size(); i++)
+                ASSERT_NEAR (hY[i], host_result[i], 1e-7);
+
+        if ( typeid(T) == typeid(cl_double) )
+            for(int i = 0; i < hY.size(); i++)
+                ASSERT_NEAR (hY[i], host_result[i], 1e-14);
+
+        cl_status = ::clEnqueueUnmapMemObject(CLSE::queue, gY.values,
+                                              host_result, 0, nullptr, nullptr);
+        ASSERT_EQ (CL_SUCCESS, cl_status);
+
+    }
+
     boost::numeric::ublas::vector<T> hY;
     boost::numeric::ublas::vector<T> hX;
     T hAlpha = 2.0;
@@ -415,6 +572,26 @@ TYPED_TEST(Blas1, axpy)
 TYPED_TEST(Blas1, axpby)
 {
     this->test_axpby();
+}
+
+TYPED_TEST(Blas1, add)
+{
+    this->test_add();
+}
+
+TYPED_TEST(Blas1, sub)
+{
+    this->test_sub();
+}
+
+TYPED_TEST(Blas1, mul)
+{
+    this->test_mul();
+}
+
+TYPED_TEST(Blas1, div)
+{
+    this->test_div();
 }
 
 int main (int argc, char* argv[])

--- a/src/tests/test-blas1.cpp
+++ b/src/tests/test-blas1.cpp
@@ -24,10 +24,15 @@
 #include <boost/numeric/ublas/blas.hpp>
 
 #include "resources/clsparse_environment.h"
+#include "resources/blas1_environment.h"
+
 
 clsparseControl ClSparseEnvironment::control = NULL;
 cl_command_queue ClSparseEnvironment::queue = NULL;
 cl_context ClSparseEnvironment::context = NULL;
+
+double Blas1Environment::alpha = 0;
+double Blas1Environment::beta = 0;
 
 //cl_uint ClSparseEnvironment::N = 1024;
 static const cl_uint N = 1024;
@@ -41,6 +46,7 @@ class Blas1 : public ::testing::Test
 {
 
      using CLSE = ClSparseEnvironment;
+     using BLAS1E = Blas1Environment;
 
 
 public:
@@ -55,8 +61,8 @@ public:
 
         //hY.resize(CLSE::N, 2.0);
         //hX.resize(CLSE::N, 4.0);
-        hY = uBLAS::vector<T>(N, 2.0);
-        hX = uBLAS::vector<T>(N, 4.0);
+        hY = uBLAS::vector<T>(N, 2);
+        hX = uBLAS::vector<T>(N, 4);
 
 
         cl_int status;
@@ -78,12 +84,14 @@ public:
         gAlpha.value = clCreateBuffer(CLSE::context,
                                       CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
                                       sizeof(T), &hAlpha, &status);
+
         ASSERT_EQ(CL_SUCCESS, status);
 
 
         gBeta.value = clCreateBuffer(CLSE::context,
                                      CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
                                      sizeof(T), &hBeta, &status);
+
         ASSERT_EQ(CL_SUCCESS, status);
 
     }
@@ -97,6 +105,18 @@ public:
        clReleaseMemObject( gBeta.value );
     }
 
+    boost::numeric::ublas::vector<T> hY;
+    boost::numeric::ublas::vector<T> hX;
+    T hAlpha = BLAS1E::alpha;
+    T hBeta = BLAS1E::beta;
+
+    cldenseVector gX;
+    cldenseVector gY;
+    clsparseScalar gAlpha;
+    clsparseScalar gBeta;
+
+
+    /*  Test functions  */
 
     void test_reduce()
     {
@@ -214,11 +234,11 @@ public:
         //  GPU result;
         if (typeid(T) == typeid(cl_float))
         {
-            status = cldenseSscale(&gX, &gX, &gAlpha, CLSE::control);
+            status = cldenseSscale(&gX, &gAlpha, &gX, CLSE::control);
         }
         else if ( typeid(T) == typeid(cl_double) )
         {
-            status = cldenseDscale(&gX, &gX, &gAlpha, CLSE::control);
+            status = cldenseDscale(&gX, &gAlpha, &gX, CLSE::control);
         }
 
         ASSERT_EQ (clsparseSuccess, status);
@@ -340,7 +360,7 @@ public:
 
         ASSERT_EQ (clsparseSuccess, status);
 
-        hY = uBLAS::blas_1::axpy (uBLAS::blas_1::scal(hY, hBeta), hAlpha, hX);
+        hY = uBLAS::blas_1::axpy(uBLAS::blas_1::scal(hY, hBeta), hAlpha, hX);
 
         // Map device data to host
         cl_int cl_status;
@@ -522,15 +542,7 @@ public:
 
     }
 
-    boost::numeric::ublas::vector<T> hY;
-    boost::numeric::ublas::vector<T> hX;
-    T hAlpha = 2.0;
-    T hBeta = 4.0;
 
-    cldenseVector gX;
-    cldenseVector gY;
-    clsparseScalar gAlpha;
-    clsparseScalar gBeta;
 };
 
 
@@ -598,12 +610,16 @@ int main (int argc, char* argv[])
 {
 
     using CLSE = ClSparseEnvironment;
+    using BLAS1E = Blas1Environment;
 
 
     std::string platform;
     cl_platform_type pID;
     cl_uint dID;
     cl_uint size;
+
+    double alpha;
+    double beta;
 
     po::options_description desc("Allowed options");
 
@@ -613,8 +629,12 @@ int main (int argc, char* argv[])
              "OpenCL platform: AMD or NVIDIA.")
             ("device,d", po::value(&dID)->default_value(0),
              "Device id within platform.")
-            ("Size,n",po::value(&size)->default_value(1024),
-             "Size of the vectors used for testing");
+            ("size,n",po::value(&size)->default_value(1024),
+             "Size of the vectors used for testing")
+            ("alpha,a", po::value(&alpha)->default_value(2),
+             "Alpha coefficient for blas1 operations i.e. r = alpha * x + beta * y")
+            ("beta,b", po::value(&beta)->default_value(4),
+             "Beta coefficient for blas1 operations i.e. r = alpha * x + beta * y");
 
 
     po::variables_map vm;
@@ -662,6 +682,7 @@ int main (int argc, char* argv[])
     ::testing::InitGoogleTest(&argc, argv);
     //order does matter!
     ::testing::AddGlobalTestEnvironment( new CLSE(pID, dID, size));
+    ::testing::AddGlobalTestEnvironment( new BLAS1E(alpha, beta));
 
     return RUN_ALL_TESTS();
 

--- a/src/tests/test-blas1.cpp
+++ b/src/tests/test-blas1.cpp
@@ -214,11 +214,11 @@ public:
         //  GPU result;
         if (typeid(T) == typeid(cl_float))
         {
-            status = cldenseSscale(&gX, &gAlpha, CLSE::control);
+            status = cldenseSscale(&gX, &gX, &gAlpha, CLSE::control);
         }
         else if ( typeid(T) == typeid(cl_double) )
         {
-            status = cldenseDscale(&gX, &gAlpha, CLSE::control);
+            status = cldenseDscale(&gX, &gX, &gAlpha, CLSE::control);
         }
 
         ASSERT_EQ (clsparseSuccess, status);
@@ -290,11 +290,11 @@ public:
         //  GPU result;
         if (typeid(T) == typeid(cl_float))
         {
-            status = cldenseSaxpy(&gY, &gAlpha, &gX, CLSE::control);
+            status = cldenseSaxpy(&gY, &gAlpha, &gX, &gY, CLSE::control);
         }
         else if ( typeid(T) == typeid(cl_double) )
         {
-            status = cldenseDaxpy(&gY, &gAlpha, &gX, CLSE::control);
+            status = cldenseDaxpy(&gY, &gAlpha, &gX, &gY, CLSE::control);
         }
 
         ASSERT_EQ (clsparseSuccess, status);
@@ -331,11 +331,11 @@ public:
         //  GPU result;
         if (typeid(T) == typeid(cl_float))
         {
-            status = cldenseSaxpby(&gY, &gAlpha, &gX, &gBeta, CLSE::control);
+            status = cldenseSaxpby(&gY, &gAlpha, &gX, &gBeta, &gY, CLSE::control);
         }
         else if ( typeid(T) == typeid(cl_double) )
         {
-            status = cldenseDaxpby(&gY, &gAlpha, &gX, &gBeta, CLSE::control);
+            status = cldenseDaxpby(&gY, &gAlpha, &gX, &gBeta, &gY, CLSE::control);
         }
 
         ASSERT_EQ (clsparseSuccess, status);


### PR DESCRIPTION
Here I took care of scale, axpy, axpby functions. Now they have similar interface, more flexible than previous. I removed the implementation based on cldenseVectorPrivate and switched to clsparse::vector.