### PR TITLE
Modify rowBlock generation mechanism

### DIFF
--- a/samples/sample-cg.cpp
+++ b/samples/sample-cg.cpp
@@ -191,7 +191,7 @@ int main (int argc, char* argv[])
     // the structure will not be calculated and clSPARSE will run the vectorized
     // version of SpMV instead of adaptive;
     clsparseCsrMetaSize( &A, control );
-    A.rowBlocks = ::clCreateBuffer( context, CL_MEM_READ_WRITE,
+    A.rowBlocks = ::clCreateBuffer( context(), CL_MEM_READ_WRITE,
             A.rowBlockSize * sizeof( cl_ulong ), NULL, &cl_status );
     clsparseCsrMetaCompute( &A, control );
 

--- a/samples/sample-cg.cpp
+++ b/samples/sample-cg.cpp
@@ -171,11 +171,6 @@ int main (int argc, char* argv[])
     A.num_rows = row;
     A.num_cols = col;
 
-    // This function allocates memory for rowBlocks structure. If not called
-    // the structure will not be calculated and clSPARSE will run the vectorized
-    // version of SpMV instead of adaptive;
-    clsparseCsrMetaSize( &A, control );
-
     // Allocate memory for CSR matrix
     A.values = ::clCreateBuffer( context(), CL_MEM_READ_ONLY,
                                  A.num_nonzeros * sizeof( float ), NULL, &cl_status );
@@ -192,6 +187,13 @@ int main (int argc, char* argv[])
 
     fileError = clsparseSCsrMatrixfromFile( &A, matrix_path.c_str( ), control );
 
+    // This function allocates memory for rowBlocks structure. If not called
+    // the structure will not be calculated and clSPARSE will run the vectorized
+    // version of SpMV instead of adaptive;
+    clsparseCsrMetaSize( &A, control );
+    A.rowBlocks = ::clCreateBuffer( context, CL_MEM_READ_WRITE,
+            A.rowBlockSize * sizeof( cl_ulong ), NULL, &cl_status );
+    clsparseCsrMetaCompute( &A, control );
 
     if (fileError != clsparseSuccess)
     {

--- a/samples/sample-spmv.cpp
+++ b/samples/sample-spmv.cpp
@@ -43,8 +43,9 @@
  * for given matrix stored in CSR format. It is enough to calculate the
  * structure once, it is related to its nnz pattern.
  *
- * rowBlocks are also calculated while reading matrix from disk with function
+ * After the matrix is read from disk with the function
  * clsparse<S,D>CsrMatrixfromFile
+ * the rowBlock structure can be calculated using clsparseCsrMetaCompute
  *
  * If rowBlocks are calculated the clsparseCsrMatrix.rowBlocks field is not null.
  *
@@ -203,11 +204,6 @@ int main (int argc, char* argv[])
     A.num_rows = row;
     A.num_cols = col;
 
-    // This function allocates memory for rowBlocks structure. If not called
-    // the structure will not be calculated and clSPARSE will run the vectorized
-    // version of SpMV instead of adaptive;
-    clsparseCsrMetaSize( &A, control );
-
     // Allocate memory for CSR matrix
     A.values = ::clCreateBuffer( context(), CL_MEM_READ_ONLY,
                                  A.num_nonzeros * sizeof( float ), NULL, &cl_status );
@@ -224,6 +220,13 @@ int main (int argc, char* argv[])
 
     fileError = clsparseSCsrMatrixfromFile( &A, matrix_path.c_str( ), control );
 
+    // This function allocates memory for rowBlocks structure. If not called
+    // the structure will not be calculated and clSPARSE will run the vectorized
+    // version of SpMV instead of adaptive;
+    clsparseCsrMetaSize( &A, control );
+    A.rowBlocks = ::clCreateBuffer( context, CL_MEM_READ_WRITE,
+            A.rowBlockSize * sizeof( cl_ulong ), NULL, &cl_status );
+    clsparseCsrMetaCompute( &A, control );
 
     if (fileError != clsparseSuccess)
     {

--- a/samples/sample-spmv.cpp
+++ b/samples/sample-spmv.cpp
@@ -224,7 +224,7 @@ int main (int argc, char* argv[])
     // the structure will not be calculated and clSPARSE will run the vectorized
     // version of SpMV instead of adaptive;
     clsparseCsrMetaSize( &A, control );
-    A.rowBlocks = ::clCreateBuffer( context, CL_MEM_READ_WRITE,
+    A.rowBlocks = ::clCreateBuffer( context(), CL_MEM_READ_WRITE,
             A.rowBlockSize * sizeof( cl_ulong ), NULL, &cl_status );
     clsparseCsrMetaCompute( &A, control );
 

--- a/src/benchmarks/clsparse-bench/functions/clfunc_xBiCGStab.hpp
+++ b/src/benchmarks/clsparse-bench/functions/clfunc_xBiCGStab.hpp
@@ -115,7 +115,6 @@ public:
         csrMtx.num_nonzeros = nnz;
         csrMtx.num_rows = row;
         csrMtx.num_cols = col;
-        clsparseCsrMetaSize( &csrMtx, control );
 
         cl_int status;
         csrMtx.values = ::clCreateBuffer( ctx, CL_MEM_READ_ONLY,
@@ -130,10 +129,6 @@ public:
             ( csrMtx.num_rows + 1 ) * sizeof( cl_int ), NULL, &status );
         CLSPARSE_V( status, "::clCreateBuffer csrMtx.rowOffsets" );
 
-        csrMtx.rowBlocks = ::clCreateBuffer( ctx, CL_MEM_READ_ONLY,
-            csrMtx.rowBlockSize * sizeof( cl_ulong ), NULL, &status );
-        CLSPARSE_V( status, "::clCreateBuffer csrMtx.rowBlocks" );
-
         if(typeid(T) == typeid(float))
             fileError = clsparseSCsrMatrixfromFile( &csrMtx, sparseFile.c_str( ), control );
         else if (typeid(T) == typeid(double))
@@ -143,6 +138,12 @@ public:
 
         if( fileError != clsparseSuccess )
             throw std::runtime_error( "Could not read matrix market data from disk" );
+
+        clsparseCsrMetaSize( &csrMtx, control );
+        csrMtx.rowBlocks = ::clCreateBuffer( ctx, CL_MEM_READ_WRITE,
+                csrMtx.rowBlockSize * sizeof( cl_ulong ), NULL, &status );
+        CLSPARSE_V( status, "::clCreateBuffer csrMtx.rowBlocks" );
+        clsparseCsrMetaCompute( &csrMtx, control );
 
         // Initialize the dense X & Y vectors that we multiply against the sparse matrix
         clsparseInitVector( &x );

--- a/src/benchmarks/clsparse-bench/functions/clfunc_xCG.hpp
+++ b/src/benchmarks/clsparse-bench/functions/clfunc_xCG.hpp
@@ -114,7 +114,6 @@ public:
         csrMtx.num_nonzeros = nnz;
         csrMtx.num_rows = row;
         csrMtx.num_cols = col;
-        clsparseCsrMetaSize( &csrMtx, control );
 
         cl_int status;
         csrMtx.values = ::clCreateBuffer( ctx, CL_MEM_READ_ONLY,
@@ -129,10 +128,6 @@ public:
             ( csrMtx.num_rows + 1 ) * sizeof( cl_int ), NULL, &status );
         CLSPARSE_V( status, "::clCreateBuffer csrMtx.rowOffsets" );
 
-        csrMtx.rowBlocks = ::clCreateBuffer( ctx, CL_MEM_READ_ONLY,
-            csrMtx.rowBlockSize * sizeof( cl_ulong ), NULL, &status );
-        CLSPARSE_V( status, "::clCreateBuffer csrMtx.rowBlocks" );
-
         if(typeid(T) == typeid(float))
             fileError = clsparseSCsrMatrixfromFile( &csrMtx, sparseFile.c_str( ), control );
         else if (typeid(T) == typeid(double))
@@ -142,6 +137,12 @@ public:
 
         if( fileError != clsparseSuccess )
             throw std::runtime_error( "Could not read matrix market data from disk" );
+
+        clsparseCsrMetaSize( &csrMtx, control );
+        csrMtx.rowBlocks = ::clCreateBuffer( ctx, CL_MEM_READ_WRITE,
+                csrMtx.rowBlockSize * sizeof( cl_ulong ), NULL, &status );
+        CLSPARSE_V( status, "::clCreateBuffer csrMtx.rowBlocks" );
+        clsparseCsrMetaCompute( &csrMtx, control );
 
         // Initialize the dense X & Y vectors that we multiply against the sparse matrix
         clsparseInitVector( &x );

--- a/src/benchmarks/clsparse-bench/functions/clfunc_xCsr2Coo.hpp
+++ b/src/benchmarks/clsparse-bench/functions/clfunc_xCsr2Coo.hpp
@@ -119,7 +119,6 @@ public:
 		csrMtx.num_nonzeros = nnz;
 		csrMtx.num_rows     = row;
 		csrMtx.num_cols     = col;
-		clsparseCsrMetaSize(&csrMtx, control);
 
 		cl_int status;
 		csrMtx.values = ::clCreateBuffer(ctx, CL_MEM_READ_ONLY, csrMtx.num_nonzeros * sizeof(T), NULL, &status);
@@ -131,9 +130,6 @@ public:
 		csrMtx.rowOffsets = ::clCreateBuffer(ctx, CL_MEM_READ_ONLY, (csrMtx.num_rows + 1) * sizeof(cl_int), NULL, &status);
 		CLSPARSE_V(status, "::clCreateBuffer csrMtx.rowOffsets");
 
-		csrMtx.rowBlocks = ::clCreateBuffer(ctx, CL_MEM_READ_ONLY, csrMtx.rowBlockSize * sizeof(cl_ulong), NULL, &status);
-		CLSPARSE_V(status, "::clCreateBuffer csrMtx.rowBlocks");
-
 		if (typeid(T) == typeid(float))
 			fileError = clsparseSCsrMatrixfromFile(&csrMtx, sparseFile.c_str(), control);
 		else if (typeid(T) == typeid(double))
@@ -143,6 +139,11 @@ public:
 
 		if (fileError != clsparseSuccess)
 			throw std::runtime_error("Could not read matrix market data from disk");
+
+		clsparseCsrMetaSize(&csrMtx, control);
+		csrMtx.rowBlocks = ::clCreateBuffer(ctx, CL_MEM_READ_WRITE, csrMtx.rowBlockSize * sizeof(cl_ulong), NULL, &status );
+		CLSPARSE_V( status, "::clCreateBuffer csrMtx.rowBlocks" );
+		clsparseCsrMetaCompute(&csrMtx, control);
 
 		// Initialize the output coo matrix
 		clsparseInitCooMatrix(&cooMtx);

--- a/src/benchmarks/clsparse-bench/functions/clfunc_xSpMdV.hpp
+++ b/src/benchmarks/clsparse-bench/functions/clfunc_xSpMdV.hpp
@@ -114,7 +114,6 @@ public:
         csrMtx.num_nonzeros = nnz;
         csrMtx.num_rows = row;
         csrMtx.num_cols = col;
-        clsparseCsrMetaSize( &csrMtx, control );
 
         cl_int status;
         csrMtx.values = ::clCreateBuffer( ctx, CL_MEM_READ_ONLY,
@@ -129,10 +128,6 @@ public:
             ( csrMtx.num_rows + 1 ) * sizeof( cl_int ), NULL, &status );
         CLSPARSE_V( status, "::clCreateBuffer csrMtx.rowOffsets" );
 
-        csrMtx.rowBlocks = ::clCreateBuffer( ctx, CL_MEM_READ_ONLY,
-            csrMtx.rowBlockSize * sizeof( cl_ulong ), NULL, &status );
-        CLSPARSE_V( status, "::clCreateBuffer csrMtx.rowBlocks" );
-
         if(typeid(T) == typeid(float))
             fileError = clsparseSCsrMatrixfromFile( &csrMtx, sparseFile.c_str( ), control );
         else if (typeid(T) == typeid(double))
@@ -142,6 +137,12 @@ public:
 
         if( fileError != clsparseSuccess )
             throw clsparse::io_exception( "Could not read matrix market data from disk" );
+
+        clsparseCsrMetaSize( &csrMtx, control );
+        csrMtx.rowBlocks = ::clCreateBuffer( ctx, CL_MEM_READ_WRITE,
+                csrMtx.rowBlockSize * sizeof( cl_ulong ), NULL, &status );
+        CLSPARSE_V( status, "::clCreateBuffer csrMtx.rowBlocks" );
+        clsparseCsrMetaCompute( &csrMtx, control );
 
         // Initialize the dense X & Y vectors that we multiply against the sparse matrix
         clsparseInitVector( &x );

--- a/src/library/internal/computeRowBlocks.hpp
+++ b/src/library/internal/computeRowBlocks.hpp
@@ -47,7 +47,7 @@ static inline unsigned int flp2(unsigned int x)
 // working on each row. If you have 5 rows, only 32 threads could
 // reliably work on each row because our reduction assumes power-of-2.
 template< typename rowBlockType >
-static inline rowBlockType numThreadsForReduction(rowBlockType num_rows)
+static inline rowBlockType numThreadsForReduction(const rowBlockType num_rows)
 {
 #if defined(__INTEL_COMPILER)
     return 256 >> (_bit_scan_reverse(num_rows-1)+1);
@@ -89,7 +89,7 @@ static inline rowBlockType numThreadsForReduction(rowBlockType num_rows)
 //  rowBlockType is currently instantiated as ulong
 template< typename rowBlockType >
 void ComputeRowBlocks( rowBlockType* rowBlocks, size_t& rowBlockSize, const int* rowDelimiters,
-                       int nRows, int blkSize, int blkMultiplier, int rows_for_vector, bool allocate_row_blocks = true )
+                       const int nRows, const int blkSize, const int blkMultiplier, const int rows_for_vector, const bool allocate_row_blocks = true )
 {
     rowBlockType* rowBlocksBase;
     int total_row_blocks = 1; // Start at one because of rowBlock[0]
@@ -255,6 +255,14 @@ void ComputeRowBlocks( rowBlockType* rowBlocks, size_t& rowBlockSize, const int*
     }
     else
         rowBlockSize = 2 * total_row_blocks;
+}
+
+inline size_t ComputeRowBlocksSize( const int* rowDelimiters, const int nRows, const unsigned int blkSize,
+                                    const unsigned int blkMultiplier, const unsigned int rows_for_vector )
+{
+    size_t rowBlockSize;
+    ComputeRowBlocks( (cl_uint*)NULL, rowBlockSize, rowDelimiters, nRows, blkSize, blkMultiplier, rows_for_vector, false );
+    return rowBlockSize;
 }
 
 #endif

--- a/src/library/io/mm-reader.cpp
+++ b/src/library/io/mm-reader.cpp
@@ -594,29 +594,7 @@ clsparseSCsrMatrixfromFile(clsparseCsrMatrix* csrMatx, const char* filePath, cls
     while( current_row <= pCsrMatx->num_rows )
         iCsrRowOffsets[ current_row++ ] = pCsrMatx->num_nonzeros;
 
-
-    // Compute the csr matrix meta data and fill in buffers
-    if( pCsrMatx->rowBlockSize )
-    {
-        clMemRAII< cl_ulong > rRowBlocks( control->queue( ), pCsrMatx->rowBlocks );
-        ComputeRowBlocks( (cl_ulong*)NULL, pCsrMatx->rowBlockSize, iCsrRowOffsets, pCsrMatx->num_rows, BLKSIZE, BLOCK_MULTIPLIER, ROWS_FOR_VECTOR, false );
-
-        // matrix SMALL/Reuters/Reuters911.mtx throws here segfault
-        // due to wrong estimation of rowBlockSize in function clsparseCsrMetaSize.
-        cl_int mapStatus = 0;
-        cl_ulong* ulCsrRowBlocks = rRowBlocks.clMapMem( CL_TRUE, CL_MAP_WRITE_INVALIDATE_REGION, pCsrMatx->rowBlocksOffset( ), pCsrMatx->rowBlockSize, &mapStatus );
-
-        if (mapStatus != CL_SUCCESS)
-        {
-            std::cerr << "Error: Row block estimation too low, invalid value returned from mapping" << std::endl;
-            return clsparseInvalidValue;
-        }
-
-        ComputeRowBlocks( ulCsrRowBlocks, pCsrMatx->rowBlockSize, iCsrRowOffsets, pCsrMatx->num_rows, BLKSIZE, BLOCK_MULTIPLIER, ROWS_FOR_VECTOR, true );
-    }
-
     return clsparseSuccess;
-
 }
 
 clsparseStatus
@@ -676,18 +654,7 @@ clsparseDCsrMatrixfromFile(clsparseCsrMatrix* csrMatx, const char* filePath, cls
     while( current_row <= pCsrMatx->num_rows )
         iCsrRowOffsets[ current_row++ ] = pCsrMatx->num_nonzeros;
 
-    // Compute the csr matrix meta data and fill in buffers
-    if( pCsrMatx->rowBlockSize )
-    {
-        clMemRAII< cl_ulong > rRowBlocks( control->queue( ), pCsrMatx->rowBlocks );
-        ComputeRowBlocks( (cl_ulong*)NULL, pCsrMatx->rowBlockSize, iCsrRowOffsets, pCsrMatx->num_rows, BLKSIZE, BLOCK_MULTIPLIER, ROWS_FOR_VECTOR, false );
-        cl_ulong* ulCsrRowBlocks = rRowBlocks.clMapMem( CL_TRUE, CL_MAP_WRITE_INVALIDATE_REGION, pCsrMatx->rowBlocksOffset( ), pCsrMatx->rowBlockSize );
-
-        ComputeRowBlocks( ulCsrRowBlocks, pCsrMatx->rowBlockSize, iCsrRowOffsets, pCsrMatx->num_rows, BLKSIZE, BLOCK_MULTIPLIER, ROWS_FOR_VECTOR, true );
-    }
-
     return clsparseSuccess;
-
 }
 
 //clsparseStatus
@@ -744,16 +711,6 @@ clsparseDCsrMatrixfromFile(clsparseCsrMatrix* csrMatx, const char* filePath, cls
 //            iCsrRowOffsets[ current_row++ ] = i;
 //    }
 //    iCsrRowOffsets[ current_row ] = pCsrMatx->num_nonzeros;
-
-//    // Compute the csr matrix meta data and fill in buffers
-//    if( pCsrMatx->rowBlockSize )
-//    {
-//        clMemRAII< cl_ulong > rRowBlocks( control->queue( ), pCsrMatx->rowBlocks );
-//        ComputeRowBlocks( (cl_ulong*)NULL, pCsrMatx->rowBlockSize, iCsrRowOffsets, pCsrMatx->num_rows, BLKSIZE, BLOCK_MULTIPLIER, ROWS_FOR_VECTOR, false );
-//        cl_ulong* ulCsrRowBlocks = rRowBlocks.clMapMem( CL_TRUE, CL_MAP_WRITE_INVALIDATE_REGION, pCsrMatx->rowBlocksOffset( ), pCsrMatx->rowBlockSize );
-
-//        ComputeRowBlocks( ulCsrRowBlocks, pCsrMatx->rowBlockSize, iCsrRowOffsets, pCsrMatx->num_rows, BLKSIZE, BLOCK_MULTIPLIER, ROWS_FOR_VECTOR, true );
-//    }
 
 //    return clsparseSuccess;
 //}

--- a/src/tests/resources/csr_matrix_environment.h
+++ b/src/tests/resources/csr_matrix_environment.h
@@ -60,7 +60,6 @@ public:
         csrSMatrix.num_nonzeros = n_vals;
         csrSMatrix.num_rows = n_rows;
         csrSMatrix.num_cols = n_cols;
-        clsparseCsrMetaSize( &csrSMatrix, CLSE::control );
 
          //  Load single precision data from file; this API loads straight into GPU memory
         cl_int status;
@@ -73,12 +72,14 @@ public:
         csrSMatrix.rowOffsets = ::clCreateBuffer( context, CL_MEM_READ_ONLY,
                                                   ( csrSMatrix.num_rows + 1 ) * sizeof( cl_int ), NULL, &status );
 
-        csrSMatrix.rowBlocks = ::clCreateBuffer( context, CL_MEM_READ_WRITE,
-                                                 csrSMatrix.rowBlockSize * sizeof( cl_ulong ), NULL, &status );
-
         clsparseStatus fileError = clsparseSCsrMatrixfromFile( &csrSMatrix, file_name.c_str( ), CLSE::control );
         if( fileError != clsparseSuccess )
             throw std::runtime_error( "Could not read matrix market data from disk" );
+
+        clsparseCsrMetaSize( &csrSMatrix, CLSE::control );
+        csrSMatrix.rowBlocks = ::clCreateBuffer( context, CL_MEM_READ_WRITE,
+                                                 csrSMatrix.rowBlockSize * sizeof( cl_ulong ), NULL, &status );
+        clsparseCsrMetaCompute( &csrSMatrix, CLSE::control );
 
         //reassign the new matrix dimmesnions calculated clsparseCCsrMatrixFromFile to global variables
         n_vals = csrSMatrix.num_nonzeros;


### PR DESCRIPTION
Fixes Issue #127 

Previous modifications to the row block generation algorithm make it difficult to statically know the maximum size of the row block buffer -- in the absolute worst case, it could technically now be as large as the number of rows.

The bug encountered in Issue #127 are because our static estimate (which was used to allocate the rowBlocks buffer) was too small. I've modified the code in a number of places -- now, clsparseCsrMetaSize dynamically calculates how many rowBlocks there will be.

This must be done *after* the matrix is read in, because the row blocks are based on matrix structure. As such, I've removed the row block calculation logic from clsparse*CsrMatrixfromFile() and now explicitly calculate the meta data in all of our code that relied on that function.