### PR TITLE
Fixing Minor validateMemObject Things

### DIFF
--- a/src/library/internal/clsparse-validate.cpp
+++ b/src/library/internal/clsparse-validate.cpp
@@ -64,7 +64,7 @@ validateMemObject( cl_mem mem, size_t required_size)
         size_t current_size;
         clGetMemObjectInfo(mem, CL_MEM_SIZE,
                             sizeof(current_size), &current_size, NULL);
-        if(current_size != required_size)
+        if(current_size < required_size)
             return clsparseInvalidSize;
 #ifndef NDEBUG
      printf("Mem size: %lu\n", current_size);

--- a/src/library/internal/clsparse-validate.cpp
+++ b/src/library/internal/clsparse-validate.cpp
@@ -21,7 +21,7 @@
 clsparseStatus
 validateMemObject(clsparseScalarPrivate &scalar, size_t required_size)
 {
-#if (BUILD_CLVERSION >= 200)
+#if !defined(NDEBUG) && (BUILD_CLVERSION >= 200)
     std::cout << "Don't know how to validate SVM void* buffer" << std::endl;
     return clsparseSuccess;
 #else
@@ -32,7 +32,7 @@ validateMemObject(clsparseScalarPrivate &scalar, size_t required_size)
 clsparseStatus
 validateMemObject(cldenseVector &vector, size_t required_size)
 {
-#if (BUILD_CLVERSION >= 200)
+#if !defined(NDEBUG) && (BUILD_CLVERSION >= 200)
     std::cout << "Don't know how to validate SVM void* buffer" << std::endl;
     return clsparseSuccess;
 #else
@@ -43,18 +43,20 @@ validateMemObject(cldenseVector &vector, size_t required_size)
 clsparseStatus
 validateMemObject(void* mem, size_t required_size)
 {
+#ifndef NDEBUG
     std::cout << "validateMemObject void* buffer" << std::endl;
-
+#endif
     return clsparseSuccess;
 }
 
 clsparseStatus
 validateMemObject( cl_mem mem, size_t required_size)
 {
+#ifndef NDEBUG
     //check if valid mem object,
     cl_mem_object_type mem_type = 0;
     clGetMemObjectInfo(mem, CL_MEM_TYPE, sizeof(mem_type), &mem_type, NULL);
-    if(mem_type != CL_MEM_OBJECT_BUFFER)
+    if (mem_type != CL_MEM_OBJECT_BUFFER)
     {
         return clsparseInvalidMemObj;
     }
@@ -64,14 +66,12 @@ validateMemObject( cl_mem mem, size_t required_size)
         size_t current_size;
         clGetMemObjectInfo(mem, CL_MEM_SIZE,
                             sizeof(current_size), &current_size, NULL);
-        if(current_size < required_size)
+        std::cout << "[validateMemObject] Buffer size: " << current_size << " bytes. ";
+        std::cout << "Required size: " << required_size << " bytes." << std::endl;
+        if (current_size < required_size)
             return clsparseInvalidSize;
-#ifndef NDEBUG
-     printf("Mem size: %lu\n", current_size);
-     printf("Required size: %lu\n", required_size);
-#endif
     }
-
+#endif
     return clsparseSuccess;
 }
 
@@ -88,6 +88,7 @@ validateMemObjectSize(size_t element_size,
                        cl_mem mem,
                        size_t off_mem)
 {
+#ifndef NDEBUG
     size_t mem_size; //cl_mem current size
     size_t vec_size = count * element_size;
     off_mem *= element_size; //it's a copy
@@ -109,6 +110,6 @@ validateMemObjectSize(size_t element_size,
     {
         return clsparseInsufficientMemory;
     }
-
+#endif
     return clsparseSuccess;
 }

--- a/src/tests/test-blas2.cpp
+++ b/src/tests/test-blas2.cpp
@@ -186,6 +186,7 @@ public:
                 //std::cout << "\tFloat hY[" << i << "] = " << std::scientific << hY[i] << " (0x" << std::hex << *(uint32_t *)&hY[i] << "), " << std::dec;
                 //std::cout << "host_result[" << i << "] = " << std::scientific << host_result[i] << " (0x" << std::hex << *(uint32_t *)&host_result[i] << ")" << std::dec << std::endl;
             }
+#ifndef NDEBUG
             if (extended_precision)
             {
                 std::cout << "Float Min ulps: " << min_ulps << std::endl;
@@ -193,6 +194,7 @@ public:
                 std::cout << "Float Total ulps: " << total_ulps << std::endl;
                 std::cout << "Float Average ulps: " << (double)total_ulps/(double)hY.size() <<  " (Size: " << hY.size() << ")" << std::endl;
             }
+#endif
 
             for (int i = 0; i < hY.size(); i++)
             {
@@ -275,10 +277,12 @@ public:
             }
             if (extended_precision)
             {
+#ifndef NDEBUG
                 std::cout << "Double Min ulps: " << min_ulps << std::endl;
                 std::cout << "Double Max ulps: " << max_ulps << std::endl;
                 std::cout << "Double Total ulps: " << total_ulps << std::endl;
                 std::cout << "Double Average ulps: " << (double)total_ulps/(double)hY.size() <<  " (Size: " << hY.size() << ")" << std::endl;
+#endif
 
                 for (int i = 0; i < hY.size(); i++)
                 {


### PR DESCRIPTION
This fixes #144 and fixes #145 

The first change, as discussed in #144, loosens the validateMemObject function. Previously, this claimed that a memory object was invalid if its size was not exactly the same as the size required by the data structure. Instead, this function now *returns failure* if the current size of the memory object is less than the required size. If the current size is larger than the required size, it will return successfully. @jpola, could you confirm that this is OK?

The second change should handle #145. I simply added ifdefs around the validateMemObject functions such that the functions will always return success when we are not in a Debug build. @kknox, does this work for you?