### PR TITLE
Changed double precision pragmas for HW w/o DPFP

### DIFF
--- a/src/library/blas1/cldense-axpby.hpp
+++ b/src/library/blas1/cldense-axpby.hpp
@@ -42,11 +42,23 @@ axpby(clsparse::array_base<T>& pR,
 
     const int group_size = 256; // this or higher? control->max_wg_size?
 
-    const std::string params = std::string()
+    std::string params = std::string()
             + " -DSIZE_TYPE=" + OclTypeTraits<cl_ulong>::type
             + " -DVALUE_TYPE=" + OclTypeTraits<T>::type
             + " -DWG_SIZE=" + std::to_string( group_size )
             + " -D" + ElementWiseOperatorTrait<OP>::operation;
+
+    if(typeid(T) == typeid(cl_double))
+    {
+        params.append(" -DDOUBLE");
+        if (!control->dpfp_support)
+        {
+#ifndef NDEBUG
+            std::cerr << "Failure attempting to run double precision kernel on device without DPFP support." << std::endl;
+#endif
+            return clsparseInvalidDevice;
+        }
+    }
 
     cl::Kernel kernel = KernelCache::get(control->queue, "blas1", "axpby",
                                          params);

--- a/src/library/blas1/cldense-axpy.hpp
+++ b/src/library/blas1/cldense-axpy.hpp
@@ -36,11 +36,23 @@ axpy(clsparse::array_base<T>& pR,
 {
     const int group_size = 256; // this or higher? control->max_wg_size?
 
-    const std::string params = std::string()
+    std::string params = std::string()
             + " -DSIZE_TYPE=" + OclTypeTraits<cl_ulong>::type
             + " -DVALUE_TYPE=" + OclTypeTraits<T>::type
             + " -DWG_SIZE=" + std::to_string( group_size )
             + " -D" + ElementWiseOperatorTrait<OP>::operation;
+
+    if(typeid(T) == typeid(cl_double))
+    {
+        params.append(" -DDOUBLE");
+        if (!control->dpfp_support)
+        {
+#ifndef NDEBUG
+            std::cerr << "Failure attempting to run double precision kernel on device without DPFP support." << std::endl;
+#endif
+            return clsparseInvalidDevice;
+        }
+    }
 
     cl::Kernel kernel = KernelCache::get(control->queue, "blas1", "axpy",
                                          params);

--- a/src/library/blas1/cldense-dot.hpp
+++ b/src/library/blas1/cldense-dot.hpp
@@ -46,6 +46,18 @@ inner_product (cldenseVectorPrivate* partial,
             + " -DREDUCE_BLOCK_SIZE=" + std::to_string(REDUCE_BLOCK_SIZE)
             + " -DN_THREADS=" + std::to_string(nthreads);
 
+    if(typeid(T) == typeid(cl_double))
+    {
+        params.append(" -DDOUBLE");
+        if (!control->dpfp_support)
+        {
+#ifndef NDEBUG
+            std::cerr << "Failure attempting to run double precision kernel on device without DPFP support." << std::endl;
+#endif
+            return clsparseInvalidDevice;
+        }
+    }
+
     cl::Kernel kernel = KernelCache::get(control->queue,
                                          "dot", "inner_product", params);
 
@@ -153,6 +165,18 @@ inner_product (clsparse::array_base<T>& partial,
             + " -DWG_SIZE=" + std::to_string(REDUCE_BLOCK_SIZE)
             + " -DREDUCE_BLOCK_SIZE=" + std::to_string(REDUCE_BLOCK_SIZE)
             + " -DN_THREADS=" + std::to_string(nthreads);
+
+    if(typeid(T) == typeid(cl_double))
+    {
+        params.append(" -DDOUBLE");
+        if (!control->dpfp_support)
+        {
+#ifndef NDEBUG
+            std::cerr << "Failure attempting to run double precision kernel on device without DPFP support." << std::endl;
+#endif
+            return clsparseInvalidDevice;
+        }
+    }
 
     cl::Kernel kernel = KernelCache::get(control->queue,
                                          "dot", "inner_product", params);

--- a/src/library/blas1/cldense-scale.hpp
+++ b/src/library/blas1/cldense-scale.hpp
@@ -36,10 +36,22 @@ scale( clsparse::array_base<T>& pResult,
     const int group_size = 256;
     //const int group_size = control->max_wg_size;
 
-    const std::string params = std::string()
+    std::string params = std::string()
             + " -DSIZE_TYPE=" + OclTypeTraits<cl_ulong>::type
             + " -DVALUE_TYPE="+ OclTypeTraits<T>::type
             + " -DWG_SIZE=" + std::to_string(group_size);
+
+    if(typeid(T) == typeid(cl_double))
+    {
+        params.append(" -DDOUBLE");
+        if (!control->dpfp_support)
+        {
+#ifndef NDEBUG
+            std::cerr << "Failure attempting to run double precision kernel on device without DPFP support." << std::endl;
+#endif
+            return clsparseInvalidDevice;
+        }
+    }
 
     cl::Kernel kernel = KernelCache::get(control->queue,
                                          "blas1", "scale",

--- a/src/library/blas1/elementwise-transform.hpp
+++ b/src/library/blas1/elementwise-transform.hpp
@@ -65,6 +65,18 @@ elementwise_transform(cldenseVectorPrivate* r,
             + " -DWG_SIZE=" + std::to_string(wg_size)
             + " -D" + ElementWiseOperatorTrait<OP>::operation;
 
+    if(typeid(T) == typeid(cl_double))
+    {
+        params.append(" -DDOUBLE");
+        if (!control->dpfp_support)
+        {
+#ifndef NDEBUG
+            std::cerr << "Failure attempting to run double precision kernel on device without DPFP support." << std::endl;
+#endif
+            return clsparseInvalidDevice;
+        }
+    }
+
     cl::Kernel kernel = KernelCache::get(control->queue, "elementwise_transform",
                                          "transform", params);
 

--- a/src/library/blas1/reduce.hpp
+++ b/src/library/blas1/reduce.hpp
@@ -49,6 +49,18 @@ global_reduce (cldenseVectorPrivate* partial,
             + " -DN_THREADS=" + std::to_string(nthreads)
             + " -D" + ReduceOperatorTrait<OP>::operation;
 
+    if(typeid(T) == typeid(cl_double))
+    {
+        params.append(" -DDOUBLE");
+        if (!control->dpfp_support)
+        {
+#ifndef NDEBUG
+            std::cerr << "Failure attempting to run double precision kernel on device without DPFP support." << std::endl;
+#endif
+            return clsparseInvalidDevice;
+        }
+    }
+
     cl::Kernel kernel = KernelCache::get(control->queue,
                                          "reduce", "reduce", params);
 
@@ -164,6 +176,18 @@ global_reduce (clsparse::array_base<T>& partial,
             + " -DREDUCE_BLOCK_SIZE=" + std::to_string(REDUCE_BLOCK_SIZE)
             + " -DN_THREADS=" + std::to_string(nthreads)
             + " -D" + ReduceOperatorTrait<OP>::operation;
+
+    if(typeid(T) == typeid(cl_double))
+    {
+        params.append(" -DDOUBLE");
+        if (!control->dpfp_support)
+        {
+#ifndef NDEBUG
+            std::cerr << "Failure attempting to run double precision kernel on device without DPFP support." << std::endl;
+#endif
+            return clsparseInvalidDevice;
+        }
+    }
 
     cl::Kernel kernel = KernelCache::get(control->queue,
                                          "reduce", "reduce", params);

--- a/src/library/blas2/csrmv-adaptive.hpp
+++ b/src/library/blas2/csrmv-adaptive.hpp
@@ -42,6 +42,7 @@ csrmv_adaptive( const clsparseScalarPrivate* pAlpha,
     + " -DINDEX_TYPE=uint"
     + " -DROWBITS=" + std::to_string( ROW_BITS )
     + " -DWGBITS=" + std::to_string( WG_BITS )
+    + " -DVALUE_TYPE=" + OclTypeTraits<T>::type
     + " -DWG_SIZE=" + std::to_string( group_size )
     + " -DBLOCKSIZE=" + std::to_string( BLKSIZE )
     + " -DBLOCK_MULTIPLIER=" + std::to_string( BLOCK_MULTIPLIER )
@@ -49,19 +50,20 @@ csrmv_adaptive( const clsparseScalarPrivate* pAlpha,
 
     std::string options;
     if(typeid(T) == typeid(cl_double))
-        options = std::string() + " -DVALUE_TYPE=double -DDOUBLE";
-    else if(typeid(T) == typeid(cl_float))
-        options = std::string() + " -DVALUE_TYPE=float";
-    else if(typeid(T) == typeid(cl_uint))
-        options = std::string() + " -DVALUE_TYPE=uint";
-    else if(typeid(T) == typeid(cl_int))
-        options = std::string() + " -DVALUE_TYPE=int";
+    {
+        options = std::string() + " -DDOUBLE";
+        if (!control->dpfp_support)
+        {
+#ifndef NDEBUG
+            std::cerr << "Failure attempting to run double precision kernel on device without DPFP support." << std::endl;
+#endif
+            return clsparseInvalidDevice;
+        }
+    }
     else if(typeid(T) == typeid(cl_ulong))
-        options = std::string() + " -DVALUE_TYPE=ulong -DLONG";
+        options = std::string() + " -DLONG";
     else if(typeid(T) == typeid(cl_long))
-        options = std::string() + " -DVALUE_TYPE=long -DLONG";
-    else
-        return clsparseInvalidKernelArgs;
+        options = std::string() + " -DLONG";
 
     if(control->extended_precision)
         options += " -DEXTENDED_PRECISION";
@@ -122,6 +124,7 @@ csrmv_adaptive( const clsparse::array_base<T>& pAlpha,
     + " -DINDEX_TYPE=uint"
     + " -DROWBITS=" + std::to_string( ROW_BITS )
     + " -DWGBITS=" + std::to_string( WG_BITS )
+    + " -DVALUE_TYPE=" + OclTypeTraits<T>::type
     + " -DWG_SIZE=" + std::to_string( group_size )
     + " -DBLOCKSIZE=" + std::to_string( BLKSIZE )
     + " -DBLOCK_MULTIPLIER=" + std::to_string( BLOCK_MULTIPLIER )
@@ -129,19 +132,20 @@ csrmv_adaptive( const clsparse::array_base<T>& pAlpha,
 
     std::string options;
     if(typeid(T) == typeid(cl_double))
-        options = std::string() + " -DVALUE_TYPE=double -DDOUBLE";
-    else if(typeid(T) == typeid(cl_float))
-        options = std::string() + " -DVALUE_TYPE=float";
-    else if(typeid(T) == typeid(cl_uint))
-        options = std::string() + " -DVALUE_TYPE=uint";
-    else if(typeid(T) == typeid(cl_int))
-        options = std::string() + " -DVALUE_TYPE=int";
+    {
+        options = std::string() + " -DDOUBLE";
+        if (!control->dpfp_support)
+        {
+#ifndef NDEBUG
+            std::cerr << "Failure attempting to run double precision kernel on device without DPFP support." << std::endl;
+#endif
+            return clsparseInvalidDevice;
+        }
+    }
     else if(typeid(T) == typeid(cl_ulong))
-        options = std::string() + " -DVALUE_TYPE=ulong -DLONG";
+        options = std::string() + " -DLONG";
     else if(typeid(T) == typeid(cl_long))
-        options = std::string() + " -DVALUE_TYPE=long -DLONG";
-    else
-        return clsparseInvalidKernelArgs;
+        options = std::string() + " -DLONG";
 
     if(control->extended_precision)
         options += " -DEXTENDED_PRECISION";

--- a/src/library/blas2/csrmv-vector.hpp
+++ b/src/library/blas2/csrmv-vector.hpp
@@ -56,6 +56,17 @@ csrmv_vector(const clsparseScalarPrivate* pAlpha,
             + " -DWAVE_SIZE=" + std::to_string(wave_size)
             + " -DSUBWAVE_SIZE=" + std::to_string(subwave_size);
 
+    if(typeid(T) == typeid(cl_double))
+    {
+        params += " -DDOUBLE";
+        if (!control->dpfp_support)
+        {
+#ifndef NDEBUG
+            std::cerr << "Failure attempting to run double precision kernel on device without DPFP support." << std::endl;
+#endif
+            return clsparseInvalidDevice;
+        }
+    }
     if(control->extended_precision)
         params += " -DEXTENDED_PRECISION";
 
@@ -134,6 +145,17 @@ csrmv_vector(const clsparse::array_base<T>& pAlpha,
             + " -DWAVE_SIZE=" + std::to_string(wave_size)
             + " -DSUBWAVE_SIZE=" + std::to_string(subwave_size);
 
+    if(typeid(T) == typeid(cl_double))
+    {
+        params += " -DDOUBLE";
+        if (!control->dpfp_support)
+        {
+#ifndef NDEBUG
+            std::cerr << "Failure attempting to run double precision kernel on device without DPFP support." << std::endl;
+#endif
+            return clsparseInvalidDevice;
+        }
+    }
     if(control->extended_precision)
         params += " -DEXTENDED_PRECISION";
 

--- a/src/library/blas3/clsparse-csrmm.hpp
+++ b/src/library/blas3/clsparse-csrmm.hpp
@@ -118,6 +118,13 @@ const clsparseControl control )
     if( typeid( T ) == typeid( cl_double ) )
     {
         params += " -DDOUBLE";
+        if (!control->dpfp_support)
+        {
+#ifndef NDEBUG
+            std::cerr << "Failure attempting to run double precision kernel on device without DPFP support." << std::endl;
+#endif
+            return clsparseInvalidDevice;
+        }
     }
 
     cl::Kernel kernel = KernelCache::get( control->queue,

--- a/src/library/internal/clsparse-control.cpp
+++ b/src/library/internal/clsparse-control.cpp
@@ -81,6 +81,14 @@ clsparseStatus collectEnvParams(clsparseControl control)
     control->max_compute_units =
             device.getInfo<CL_DEVICE_MAX_COMPUTE_UNITS>();
 
+#ifdef CL_DEVICE_DOUBLE_FP_CONFIG
+    if ( device.getInfo<CL_DEVICE_EXTENSIONS>( ).find("cl_khr_fp64") != std::string::npos ||
+         device.getInfo<CL_DEVICE_EXTENSIONS>( ).find("cl_amd_fp64") != std::string::npos )
+    {
+        if (device.getInfo<CL_DEVICE_DOUBLE_FP_CONFIG>( ))
+            control->dpfp_support = true;
+    }
+#endif
 }
 
 clsparseControl
@@ -105,6 +113,7 @@ clsparseCreateControl( cl_command_queue queue, clsparseStatus *status )
     control->max_wg_size = 0;
     control->async = false;
     control->extended_precision = false;
+    control->dpfp_support = false;
 
     collectEnvParams( control );
 

--- a/src/library/internal/clsparse-control.hpp
+++ b/src/library/internal/clsparse-control.hpp
@@ -57,6 +57,9 @@ struct _clsparseControl
     // Should we attempt to perform compensated summation?
     cl_bool extended_precision;
 
+    // Does our device have double precision support?
+    cl_bool dpfp_support;
+
     // current device max compute units;
     cl_uint max_compute_units;
 

--- a/src/library/internal/data-types/csr-meta.hpp
+++ b/src/library/internal/data-types/csr-meta.hpp
@@ -264,7 +264,7 @@ inline size_t ComputeRowBlocksSize( const int* rowDelimiters, const int nRows, c
                                     const unsigned int blkMultiplier, const unsigned int rows_for_vector )
 {
     size_t rowBlockSize;
-    ComputeRowBlocks( (cl_uint*)NULL, rowBlockSize, rowDelimiters, nRows, blkSize, blkMultiplier, rows_for_vector, false );
+    ComputeRowBlocks( (cl_ulong*)NULL, rowBlockSize, rowDelimiters, nRows, blkSize, blkMultiplier, rows_for_vector, false );
     return rowBlockSize;
 }
 

--- a/src/library/internal/kernel-cache.cpp
+++ b/src/library/internal/kernel-cache.cpp
@@ -43,11 +43,18 @@ cl::Kernel KernelCache::getKernel(cl::CommandQueue& queue,
 {
     //!! ASSUMPTION: Kernel name == program name;
 #if (BUILD_CLVERSION >= 120)
-    std::string _params = " -cl-kernel-arg-info -cl-std=CL1.2 ";
+    std::string _params = " -cl-kernel-arg-info -cl-std=CL1.2";
 #else
-    std::string _params = " -cl-std=CL1.1 ";
+    std::string _params = " -cl-std=CL1.1";
 #endif
-    _params.append(params);
+    if (params.length() > 0)
+    {
+        // Ensure only one space after the -cl-std.
+        // >1 space can cause an Apple compiler bug. See clSPARSE issue #141.
+        if (params.at(0) != ' ')
+            _params.append(" ");
+        _params.append(params);
+    }
     std::string key;
     key.append( "[" + program_name + "/"  + kernel_name + "]");
     key.append(_params);

--- a/src/library/kernels/atomic_reduce.cl
+++ b/src/library/kernels/atomic_reduce.cl
@@ -15,30 +15,49 @@ R"(
  * limitations under the License.
  * ************************************************************************ */
 
-#ifdef cl_khr_fp64
+// No reason to include these beyond version 1.2, where double is not an extension.
+#if defined(ATOMIC_DOUBLE) && __OPENCL_VERSION__ < CL_VERSION_1_2
+  #ifdef cl_khr_fp64
     #pragma OPENCL EXTENSION cl_khr_fp64 : enable
-#elif defined(cl_amd_fp64)
+  #elif defined(cl_amd_fp64)
     #pragma OPENCL EXTENSION cl_amd_fp64 : enable
-#else
-    #error "Double precision floating point not supported by OpenCL implementation."
+  #else
+    #error "Double precision floating point not supported by this OpenCL implementation."
+  #endif
 #endif
 
-#pragma OPENCL EXTENSION cl_khr_int64_base_atomics: enable
-#pragma OPENCL EXTENSION cl_khr_int64_extended_atomics: enable
+#ifdef ATOMIC_DOUBLE
+  #if defined(cl_khr_int64_base_atomics) && defined(cl_khr_int64_extended_atomics)
+    #pragma OPENCL EXTENSION cl_khr_int64_base_atomics : enable
+    #pragma OPENCL EXTENSION cl_khr_int64_extended_atomics : enable
+  #else
+    #error "Required 64-bit atomics not supported by this OpenCL implementation."
+  #endif
+#endif
+
+#if defined(ATOMIC_FLOAT) || defined (ATOMIC_INT)
+  #if defined(cl_khr_global_int32_base_atomics) && defined(cl_khr_global_int32_extended_atomics)
+    #pragma OPENCL EXTENSION cl_khr_global_int32_base_atomics : require
+    #pragma OPENCL_EXTENSION cl_khr_global_int32_extended_atomics : require
+  #else
+    #error "Required 32-bit atomics not supported by this OpenCL implemenation."
+  #endif
+#endif
 
 #ifndef VALUE_TYPE
-#error VALUE_TYPE undefined!
+#error "VALUE_TYPE undefined!"
 #endif
 
 #ifndef SIZE_TYPE
-#error SIZE_TYPE undefined!
+#error "SIZE_TYPE undefined!"
 #endif
 
 #ifndef WG_SIZE
-#error WG_SIZE undefined!
+#error "WG_SIZE undefined!"
 #endif
+)"
 
-
+R"(
 void atomic_add_float (global VALUE_TYPE *ptr, VALUE_TYPE temp)
 {
 #ifdef ATOMIC_DOUBLE
@@ -63,7 +82,7 @@ void atomic_add_float (global VALUE_TYPE *ptr, VALUE_TYPE temp)
 )"
 
 R"(
-VALUE_TYPE operation(VALUE_TYPE A)
+inline VALUE_TYPE operation(VALUE_TYPE A)
 {
 #ifdef OP_RO_SQRT
     return sqrt(A);

--- a/src/library/kernels/blas1.cl
+++ b/src/library/kernels/blas1.cl
@@ -15,24 +15,27 @@ R"(
  * limitations under the License.
  * ************************************************************************ */
 
-#ifdef cl_khr_fp64
+// No reason to include these beyond version 1.2, where double is not an extension.
+#if defined(DOUBLE) && __OPENCL_VERSION__ < CL_VERSION_1_2
+  #ifdef cl_khr_fp64
     #pragma OPENCL EXTENSION cl_khr_fp64 : enable
-#elif defined(cl_amd_fp64)
+  #elif defined(cl_amd_fp64)
     #pragma OPENCL EXTENSION cl_amd_fp64 : enable
-#else
+  #else
     #error "Double precision floating point not supported by OpenCL implementation."
+  #endif
 #endif
 
 #ifndef VALUE_TYPE
-#error VALUE_TYPE undefined!
+#error "VALUE_TYPE undefined!"
 #endif
 
 #ifndef SIZE_TYPE
-#error SIZE_TYPE undefined!
+#error "SIZE_TYPE undefined!"
 #endif
 
 #ifndef WG_SIZE
-#error WG_SIZE undefined!
+#error "WG_SIZE undefined!"
 #endif
 )"
 

--- a/src/library/kernels/control.cl
+++ b/src/library/kernels/control.cl
@@ -16,14 +16,6 @@ R"(
  * ************************************************************************ */
 
 //do not remove. This kernel is used to measure some parameters of the device
-#ifdef cl_khr_fp64
-    #pragma OPENCL EXTENSION cl_khr_fp64 : enable
-#elif defined(cl_amd_fp64)
-    #pragma OPENCL EXTENSION cl_amd_fp64 : enable
-#else
-    #error "Double precision floating point not supported by OpenCL implementation."
-#endif
-
 #ifndef WG_SIZE
 #error WG_SIZE undefined!
 #endif

--- a/src/library/kernels/conversion_utils.cl
+++ b/src/library/kernels/conversion_utils.cl
@@ -15,41 +15,43 @@ R"(
 * limitations under the License.
 * ************************************************************************ */
 
-#ifdef cl_khr_fp64
-#pragma OPENCL EXTENSION cl_khr_fp64 : enable
-#elif defined(cl_amd_fp64)
-#pragma OPENCL EXTENSION cl_amd_fp64 : enable
-#else
-#error "Double precision floating point not supported by OpenCL implementation."
+// No reason to include these beyond version 1.2, where double is not an extension.
+#if defined(DOUBLE) && __OPENCL_VERSION__ < CL_VERSION_1_2
+  #ifdef cl_khr_fp64
+    #pragma OPENCL EXTENSION cl_khr_fp64 : enable
+  #elif defined(cl_amd_fp64)
+    #pragma OPENCL EXTENSION cl_amd_fp64 : enable
+  #else
+    #error "Double precision floating point not supported by OpenCL implementation."
+  #endif
 #endif
 
 #ifndef VALUE_TYPE
-#error VALUE_TYPE undefined!
+#error "VALUE_TYPE undefined!"
 #endif
 
 #ifndef SIZE_TYPE
-#error SIZE_TYPE undefined!
+#error "SIZE_TYPE undefined!"
 #endif
 
 #ifndef INDEX_TYPE
-#error INDEX_TYPE undefined!
+#error "INDEX_TYPE undefined!"
 #endif
 
 #ifndef WG_SIZE
-#error WG_SIZE undefined!
+#error "WG_SIZE undefined!"
 #endif
-
 
 #ifndef WAVE_SIZE
 #define WAVE_SIZE 32
 #endif
 
 #ifndef SUBWAVE_SIZE
-#error SUBWAVE_SIZE undefined!
+#error "SUBWAVE_SIZE undefined!"
 #endif
 
 #if ( (SUBWAVE_SIZE > WAVE_SIZE) || (SUBWAVE_SIZE != 2 && SUBWAVE_SIZE != 4 && SUBWAVE_SIZE != 8 && SUBWAVE_SIZE != 16 && SUBWAVE_SIZE != 32 && SUBWAVE_SIZE != 64) )
-# error SUBWAVE_SIZE is not  a power of two!
+#error "SUBWAVE_SIZE is not  a power of two!"
 #endif
 
 )"

--- a/src/library/kernels/csrmm_general.cl
+++ b/src/library/kernels/csrmm_general.cl
@@ -15,42 +15,43 @@ R"(
  * limitations under the License.
  * ************************************************************************ */
 
-#if defined DOUBLE
-    #ifdef cl_khr_fp64
+// No reason to include these beyond version 1.2, where double is not an extension.
+#if defined(DOUBLE) && __OPENCL_VERSION__ < CL_VERSION_1_2
+  #ifdef cl_khr_fp64
     #pragma OPENCL EXTENSION cl_khr_fp64 : enable
-    #elif defined(cl_amd_fp64)
+  #elif defined(cl_amd_fp64)
     #pragma OPENCL EXTENSION cl_amd_fp64 : enable
-    #else
+  #else
     #error "Double precision floating point not supported by OpenCL implementation."
-    #endif
+  #endif
 #endif
 
 #ifndef INDEX_TYPE
-#error INDEX_TYPE undefined!
+#error "INDEX_TYPE undefined!"
 #endif
 
 #ifndef VALUE_TYPE
-#error VALUE_TYPE undefined!
+#error "VALUE_TYPE undefined!"
 #endif
 
 #ifndef SIZE_TYPE
-#error SIZE_TYPE undefined!
+#error "SIZE_TYPE undefined!"
 #endif
 
 #ifndef WG_SIZE
-#error WG_SIZE undefined!
+#error "WG_SIZE undefined!"
 #endif
 
 #ifndef WAVE_SIZE
-#error WAVE_SIZE undefined!
+#error "WAVE_SIZE undefined!"
 #endif
 
 #ifndef SUBWAVE_SIZE
-#error SUBWAVE_SIZE undefined!
+#error "SUBWAVE_SIZE undefined!"
 #endif
 
 #if ( (SUBWAVE_SIZE > WAVE_SIZE) || (SUBWAVE_SIZE != 2 && SUBWAVE_SIZE != 4 && SUBWAVE_SIZE != 8 && SUBWAVE_SIZE != 16 && SUBWAVE_SIZE != 32 && SUBWAVE_SIZE != 64) )
-# error SUBWAVE_SIZE is not  a power of two!
+#error "SUBWAVE_SIZE is not  a power of two!"
 #endif
 )"
 

--- a/src/library/kernels/csrmv_adaptive.cl
+++ b/src/library/kernels/csrmv_adaptive.cl
@@ -83,7 +83,7 @@ inline unsigned long clsparse_atomic_xor(__global unsigned long * restrict const
 #ifdef ATOM64
     return atom_xor(ptr, xor_val);
 #else
-    return atomic_max((__global unsigned int*)ptr, (unsigned int)xor_val);
+    return atomic_xor((__global unsigned int*)ptr, (unsigned int)xor_val);
 #endif
 }
 

--- a/src/library/kernels/csrmv_general.cl
+++ b/src/library/kernels/csrmv_general.cl
@@ -15,40 +15,43 @@ R"(
  * limitations under the License.
  * ************************************************************************ */
 
-#ifdef cl_khr_fp64
+// No reason to include these beyond version 1.2, where double is not an extension.
+#if defined(DOUBLE) && __OPENCL_VERSION__ < CL_VERSION_1_2
+  #ifdef cl_khr_fp64
     #pragma OPENCL EXTENSION cl_khr_fp64 : enable
-#elif defined(cl_amd_fp64)
+  #elif defined(cl_amd_fp64)
     #pragma OPENCL EXTENSION cl_amd_fp64 : enable
-#else
+  #else
     #error "Double precision floating point not supported by OpenCL implementation."
+  #endif
 #endif
 
 #ifndef INDEX_TYPE
-#error INDEX_TYPE undefined!
+#error "INDEX_TYPE undefined!"
 #endif
 
 #ifndef VALUE_TYPE
-#error VALUE_TYPE undefined!
+#error "VALUE_TYPE undefined!"
 #endif
 
 #ifndef SIZE_TYPE
-#error SIZE_TYPE undefined!
+#error "SIZE_TYPE undefined!"
 #endif
 
 #ifndef WG_SIZE
-#error WG_SIZE undefined!
+#error "WG_SIZE undefined!"
 #endif
 
 #ifndef WAVE_SIZE
-#error WAVE_SIZE undefined!
+#error "WAVE_SIZE undefined!"
 #endif
 
 #ifndef SUBWAVE_SIZE
-#error SUBWAVE_SIZE undefined!
+#error "SUBWAVE_SIZE undefined!"
 #endif
 
 #if ( (SUBWAVE_SIZE > WAVE_SIZE) || (SUBWAVE_SIZE != 2 && SUBWAVE_SIZE != 4 && SUBWAVE_SIZE != 8 && SUBWAVE_SIZE != 16 && SUBWAVE_SIZE != 32 && SUBWAVE_SIZE != 64) )
-# error SUBWAVE_SIZE is not  a power of two!
+#error "SUBWAVE_SIZE is not  a power of two!"
 #endif
 
 // Knuth's Two-Sum algorithm, which allows us to add together two floating

--- a/src/library/kernels/dot.cl
+++ b/src/library/kernels/dot.cl
@@ -15,32 +15,35 @@ R"(
  * limitations under the License.
  * ************************************************************************ */
 
-#ifdef cl_khr_fp64
+// No reason to include these beyond version 1.2, where double is not an extension.
+#if defined(DOUBLE) && __OPENCL_VERSION__ < CL_VERSION_1_2
+  #ifdef cl_khr_fp64
     #pragma OPENCL EXTENSION cl_khr_fp64 : enable
-#elif defined(cl_amd_fp64)
+  #elif defined(cl_amd_fp64)
     #pragma OPENCL EXTENSION cl_amd_fp64 : enable
-#else
+  #else
     #error "Double precision floating point not supported by OpenCL implementation."
+  #endif
 #endif
 
 #ifndef VALUE_TYPE
-#error VALUE_TYPE undefined!
+#error "VALUE_TYPE undefined!"
 #endif
 
 #ifndef SIZE_TYPE
-#error SIZE_TYPE undefined!
+#error "SIZE_TYPE undefined!"
 #endif
 
 #ifndef WG_SIZE
-#error WG_SIZE undefined!
+#error "WG_SIZE undefined!"
 #endif
 
 #ifndef REDUCE_BLOCK_SIZE
-#error REDUCE_BLOCK_SIZE undefined!
+#error "REDUCE_BLOCK_SIZE undefined!"
 #endif
 
 #ifndef N_THREADS
-#error N_THREADS undefined!
+#error "N_THREADS undefined!"
 #endif
 )"
 

--- a/src/library/kernels/elementwise_transform.cl
+++ b/src/library/kernels/elementwise_transform.cl
@@ -15,24 +15,27 @@ R"(
  * limitations under the License.
  * ************************************************************************ */
 
-#ifdef cl_khr_fp64
+// No reason to include these beyond version 1.2, where double is not an extension.
+#if defined(DOUBLE) && __OPENCL_VERSION__ < CL_VERSION_1_2
+  #ifdef cl_khr_fp64
     #pragma OPENCL EXTENSION cl_khr_fp64 : enable
-#elif defined(cl_amd_fp64)
+  #elif defined(cl_amd_fp64)
     #pragma OPENCL EXTENSION cl_amd_fp64 : enable
-#else
+  #else
     #error "Double precision floating point not supported by OpenCL implementation."
+  #endif
 #endif
 
 #ifndef VALUE_TYPE
-#error VALUE_TYPE undefined!
+#error "VALUE_TYPE undefined!"
 #endif
 
 #ifndef SIZE_TYPE
-#error SIZE_TYPE undefined!
+#error "SIZE_TYPE undefined!"
 #endif
 
 #ifndef WG_SIZE
-#error WG_SIZE undefined!
+#error "WG_SIZE undefined!"
 #endif
 )"
 

--- a/src/library/kernels/matrix_utils.cl
+++ b/src/library/kernels/matrix_utils.cl
@@ -15,41 +15,43 @@ R"(
  * limitations under the License.
  * ************************************************************************ */
 
-
-#ifdef cl_khr_fp64
+// No reason to include these beyond version 1.2, where double is not an extension.
+#if defined(DOUBLE) && __OPENCL_VERSION__ < CL_VERSION_1_2
+  #ifdef cl_khr_fp64
     #pragma OPENCL EXTENSION cl_khr_fp64 : enable
-#elif defined(cl_amd_fp64)
+  #elif defined(cl_amd_fp64)
     #pragma OPENCL EXTENSION cl_amd_fp64 : enable
-#else
+  #else
     #error "Double precision floating point not supported by OpenCL implementation."
+  #endif
 #endif
 
 #ifndef INDEX_TYPE
-#error INDEX_TYPE undefined!
+#error "INDEX_TYPE undefined!"
 #endif
 
 #ifndef VALUE_TYPE
-#error VALUE_TYPE undefined!
+#error "VALUE_TYPE undefined!"
 #endif
 
 #ifndef SIZE_TYPE
-#error SIZE_TYPE undefined!
+#error "SIZE_TYPE undefined!"
 #endif
 
 #ifndef WG_SIZE
-#error WG_SIZE undefined!
+#error "WG_SIZE undefined!"
 #endif
 
 #ifndef WAVE_SIZE
-#error WAVE_SIZE undefined!
+#error "WAVE_SIZE undefined!"
 #endif
 
 #ifndef SUBWAVE_SIZE
-#error SUBWAVE_SIZE undefined!
+#error "SUBWAVE_SIZE undefined!"
 #endif
 
 #if ( (SUBWAVE_SIZE > WAVE_SIZE) || (SUBWAVE_SIZE != 2 && SUBWAVE_SIZE != 4 && SUBWAVE_SIZE != 8 && SUBWAVE_SIZE != 16 && SUBWAVE_SIZE != 32 && SUBWAVE_SIZE != 64) )
-# error SUBWAVE_SIZE is not  a power of two!
+#error "SUBWAVE_SIZE is not a power of two!"
 #endif
 
 

--- a/src/library/kernels/reduce.cl
+++ b/src/library/kernels/reduce.cl
@@ -15,32 +15,35 @@ R"(
  * limitations under the License.
  * ************************************************************************ */
 
-#ifdef cl_khr_fp64
+// No reason to include these beyond version 1.2, where double is not an extension.
+#if defined(DOUBLE) && __OPENCL_VERSION__ < CL_VERSION_1_2
+  #ifdef cl_khr_fp64
     #pragma OPENCL EXTENSION cl_khr_fp64 : enable
-#elif defined(cl_amd_fp64)
+  #elif defined(cl_amd_fp64)
     #pragma OPENCL EXTENSION cl_amd_fp64 : enable
-#else
+  #else
     #error "Double precision floating point not supported by OpenCL implementation."
+  #endif
 #endif
 
 #ifndef VALUE_TYPE
-#error VALUE_TYPE undefined!
+#error "VALUE_TYPE undefined!"
 #endif
 
 #ifndef SIZE_TYPE
-#error SIZE_TYPE undefined!
+#error "SIZE_TYPE undefined!"
 #endif
 
 #ifndef WG_SIZE
-#error WG_SIZE undefined!
+#error "WG_SIZE undefined!"
 #endif
 
 #ifndef REDUCE_BLOCK_SIZE
-#error REDUCE_BLOCK_SIZE undefined!
+#error "REDUCE_BLOCK_SIZE undefined!"
 #endif
 
 #ifndef N_THREADS
-#error N_THREADS undefined!
+#error "N_THREADS undefined!"
 #endif
 )"
 

--- a/src/library/kernels/reduce_by_key.cl
+++ b/src/library/kernels/reduce_by_key.cl
@@ -15,28 +15,31 @@ R"(
 * limitations under the License.
 * ************************************************************************ */
 
-#ifdef cl_khr_fp64
-#pragma OPENCL EXTENSION cl_khr_fp64 : enable
-#elif defined(cl_amd_fp64)
-#pragma OPENCL EXTENSION cl_amd_fp64 : enable
-#else
-#error "Double precision floating point not supported by OpenCL implementation."
+// No reason to include these beyond version 1.2, where double is not an extension.
+#if defined(DOUBLE) && __OPENCL_VERSION__ < CL_VERSION_1_2
+  #ifdef cl_khr_fp64
+    #pragma OPENCL EXTENSION cl_khr_fp64 : enable
+  #elif defined(cl_amd_fp64)
+    #pragma OPENCL EXTENSION cl_amd_fp64 : enable
+  #else
+    #error "Double precision floating point not supported by OpenCL implementation."
+  #endif
 #endif
 
 #ifndef VALUE_TYPE
-#error VALUE_TYPE undefined!
+#error "VALUE_TYPE undefined!"
 #endif
 
 #ifndef SIZE_TYPE
-#error SIZE_TYPE undefined!
+#error "SIZE_TYPE undefined!"
 #endif
 
 #ifndef KEY_TYPE
-#error KEY_TYPE undefined!
+#error "KEY_TYPE undefined!"
 #endif
 
 #ifndef WG_SIZE
-#error WG_SIZE undefined!
+#error "WG_SIZE undefined!"
 #endif
 )"
 

--- a/src/library/kernels/scan.cl
+++ b/src/library/kernels/scan.cl
@@ -15,24 +15,27 @@ R"(
 * limitations under the License.
 * ************************************************************************ */
 
-#ifdef cl_khr_fp64
-#pragma OPENCL EXTENSION cl_khr_fp64 : enable
-#elif defined(cl_amd_fp64)
-#pragma OPENCL EXTENSION cl_amd_fp64 : enable
-#else
-#error "Double precision floating point not supported by OpenCL implementation."
+// No reason to include these beyond version 1.2, where double is not an extension.
+#if defined(DOUBLE) && __OPENCL_VERSION__ < CL_VERSION_1_2
+  #ifdef cl_khr_fp64
+    #pragma OPENCL EXTENSION cl_khr_fp64 : enable
+  #elif defined(cl_amd_fp64)
+    #pragma OPENCL EXTENSION cl_amd_fp64 : enable
+  #else
+    #error "Double precision floating point not supported by OpenCL implementation."
+  #endif
 #endif
 
 #ifndef VALUE_TYPE
-#error VALUE_TYPE undefined!
+#error "VALUE_TYPE undefined!"
 #endif
 
 #ifndef SIZE_TYPE
-#error SIZE_TYPE undefined!
+#error "SIZE_TYPE undefined!"
 #endif
 
 #ifndef WG_SIZE
-#error WG_SIZE undefined!
+#error "WG_SIZE undefined!"
 #endif
 )"
 

--- a/src/library/solvers/preconditioners/preconditioner_utils.hpp
+++ b/src/library/solvers/preconditioners/preconditioner_utils.hpp
@@ -79,6 +79,17 @@ extract_diagonal(cldenseVectorPrivate* pDiag,
     if (inverse)
         params.append(" -DOP_DIAG_INVERSE");
 
+    if(typeid(T) == typeid(cl_double))
+    {
+        params.append(" -DDOUBLE");
+        if (!control->dpfp_support)
+        {
+#ifndef NDEBUG
+            std::cerr << "Failure attempting to run double precision kernel on device without DPFP support." << std::endl;
+#endif
+            return clsparseInvalidDevice;
+        }
+    }
 
     cl::Kernel kernel = KernelCache::get(control->queue, "matrix_utils",
                                          "extract_diagonal", params);
@@ -164,6 +175,17 @@ extract_diagonal(clsparse::vector<T>& pDiag,
     if (inverse)
         params.append(" -DOP_DIAG_INVERSE");
 
+    if(typeid(T) == typeid(cl_double))
+    {
+        params.append(" -DDOUBLE");
+        if (!control->dpfp_support)
+        {
+#ifndef NDEBUG
+            std::cerr << "Failure attempting to run double precision kernel on device without DPFP support." << std::endl;
+#endif
+            return clsparseInvalidDevice;
+        }
+    }
 
     cl::Kernel kernel = KernelCache::get(control->queue, "matrix_utils",
                                          "extract_diagonal", params);

--- a/src/library/transform/conversion-utils.hpp
+++ b/src/library/transform/conversion-utils.hpp
@@ -140,7 +140,7 @@ offsets_to_indices(clsparse::vector<T>& indices,
     if (elements_per_row < 4)  {  subwave_size = 2;  }
 
 
-    const std::string params = std::string ()
+    std::string params = std::string ()
             + " -DINDEX_TYPE=" + OclTypeTraits<T>::type
             //not used in this kernel but required by program conversion_utils
             + " -DVALUE_TYPE=" + OclTypeTraits<T>::type
@@ -148,6 +148,18 @@ offsets_to_indices(clsparse::vector<T>& indices,
             + " -DWG_SIZE=" + std::to_string(group_size)
             + " -DWAVE_SIZE=" + std::to_string(wave_size)
             + " -DSUBWAVE_SIZE=" + std::to_string(subwave_size);
+
+    if(typeid(T) == typeid(cl_double))
+    {
+        params.append(" -DDOUBLE");
+        if (!control->dpfp_support)
+        {
+#ifndef NDEBUG
+            std::cerr << "Failure attempting to run double precision kernel on device without DPFP support." << std::endl;
+#endif
+            return clsparseInvalidDevice;
+        }
+    }
 
     cl::Kernel kernel = KernelCache::get(control->queue, "conversion_utils",
                                          "offsets_to_indices", params);

--- a/src/library/transform/reduce-by-key.hpp
+++ b/src/library/transform/reduce-by-key.hpp
@@ -88,7 +88,7 @@ reduce_by_key( KeyVector& keys_output, ValueVector& values_output,
     std::string strProgram = "reduce_by_key";
     //  offset calculation
     {
-        const std::string params = std::string()
+        std::string params = std::string()
                 + " -DSIZE_TYPE=" + OclTypeTraits<SizeType>::type
                 + " -DVALUE_TYPE=" + OclTypeTraits<ValueType>::type
                 + " -DKEY_TYPE=" + OclTypeTraits<KeyType>::type
@@ -96,6 +96,20 @@ reduce_by_key( KeyVector& keys_output, ValueVector& values_output,
 
         cl::Kernel kernel = KernelCache::get(control->queue, strProgram,
                                              "offset_calculation", params);
+
+        if( typeid(SizeType) == typeid(cl_double)  ||
+            typeid(ValueType) == typeid(cl_double) ||
+            typeid(KeyType) == typeid(cl_double))
+        {
+            params.append(" -DDOUBLE");
+            if (!control->dpfp_support)
+            {
+#ifndef NDEBUG
+                std::cerr << "Failure attempting to run double precision kernel on device without DPFP support." << std::endl;
+#endif
+                return clsparseInvalidDevice;
+            }
+        }
 
         KernelWrap kWrapper (kernel);
 
@@ -132,11 +146,25 @@ reduce_by_key( KeyVector& keys_output, ValueVector& values_output,
     // per block scan by key
     {
 
-        const std::string params = std::string()
+        std::string params = std::string()
                 + " -DSIZE_TYPE=" + OclTypeTraits<SizeType>::type
                 + " -DVALUE_TYPE=" + OclTypeTraits<ValueType>::type
                 + " -DKEY_TYPE=" + OclTypeTraits<KeyType>::type
                 + " -DWG_SIZE=" + std::to_string(kernel_WgSize);
+
+        if( typeid(SizeType) == typeid(cl_double)  ||
+            typeid(ValueType) == typeid(cl_double) ||
+            typeid(KeyType) == typeid(cl_double))
+        {
+            params.append(" -DDOUBLE");
+            if (!control->dpfp_support)
+            {
+#ifndef NDEBUG
+                std::cerr << "Failure attempting to run double precision kernel on device without DPFP support." << std::endl;
+#endif
+                return clsparseInvalidDevice;
+            }
+        }
 
         cl::Kernel kernel = KernelCache::get(control->queue, strProgram,
                                              "per_block_scan_by_key", params);
@@ -169,11 +197,25 @@ reduce_by_key( KeyVector& keys_output, ValueVector& values_output,
 
     // intra block inclusive scan by key
     {
-        const std::string params = std::string()
+        std::string params = std::string()
                 + " -DSIZE_TYPE=" + OclTypeTraits<SizeType>::type
                 + " -DVALUE_TYPE=" + OclTypeTraits<ValueType>::type
                 + " -DKEY_TYPE=" + OclTypeTraits<KeyType>::type
                 + " -DWG_SIZE=" + std::to_string(kernel_WgSize);
+
+        if( typeid(SizeType) == typeid(cl_double)  ||
+            typeid(ValueType) == typeid(cl_double) ||
+            typeid(KeyType) == typeid(cl_double))
+        {
+            params.append(" -DDOUBLE");
+            if (!control->dpfp_support)
+            {
+#ifndef NDEBUG
+                std::cerr << "Failure attempting to run double precision kernel on device without DPFP support." << std::endl;
+#endif
+                return clsparseInvalidDevice;
+            }
+        }
 
         cl::Kernel kernel = KernelCache::get(control->queue, strProgram,
                                              "intra_block_inclusive_scan_by_key",
@@ -204,11 +246,25 @@ reduce_by_key( KeyVector& keys_output, ValueVector& values_output,
 
     // per block addition by key
     {
-        const std::string params = std::string()
+        std::string params = std::string()
                 + " -DSIZE_TYPE=" + OclTypeTraits<SizeType>::type
                 + " -DVALUE_TYPE=" + OclTypeTraits<ValueType>::type
                 + " -DKEY_TYPE=" + OclTypeTraits<KeyType>::type
                 + " -DWG_SIZE=" + std::to_string(kernel_WgSize);
+
+        if( typeid(SizeType) == typeid(cl_double)  ||
+            typeid(ValueType) == typeid(cl_double) ||
+            typeid(KeyType) == typeid(cl_double))
+        {
+            params.append(" -DDOUBLE");
+            if (!control->dpfp_support)
+            {
+#ifndef NDEBUG
+                std::cerr << "Failure attempting to run double precision kernel on device without DPFP support." << std::endl;
+#endif
+                return clsparseInvalidDevice;
+            }
+        }
 
         cl::Kernel kernel = KernelCache::get(control->queue, strProgram,
                                              "per_block_addition_by_key",
@@ -237,11 +293,25 @@ reduce_by_key( KeyVector& keys_output, ValueVector& values_output,
 
     // key value mapping
     {
-        const std::string params = std::string()
+        std::string params = std::string()
                 + " -DSIZE_TYPE=" + OclTypeTraits<SizeType>::type
                 + " -DVALUE_TYPE=" + OclTypeTraits<ValueType>::type
                 + " -DKEY_TYPE=" + OclTypeTraits<KeyType>::type
                 + " -DWG_SIZE=" + std::to_string(kernel_WgSize);
+
+        if( typeid(SizeType) == typeid(cl_double)  ||
+            typeid(ValueType) == typeid(cl_double) ||
+            typeid(KeyType) == typeid(cl_double))
+        {
+            params.append(" -DDOUBLE");
+            if (!control->dpfp_support)
+            {
+#ifndef NDEBUG
+                std::cerr << "Failure attempting to run double precision kernel on device without DPFP support." << std::endl;
+#endif
+                return clsparseInvalidDevice;
+            }
+        }
 
         cl::Kernel kernel = KernelCache::get(control->queue, strProgram,
                                              "key_value_mapping",

--- a/src/library/transform/scan.hpp
+++ b/src/library/transform/scan.hpp
@@ -100,12 +100,23 @@ scan(VectorType& output, const VectorType& input,
         //local mem size
         std::size_t lds = kernel0_WgSize * 2 * sizeof(T);
 
-        const std::string params = std::string()
+        std::string params = std::string()
                 + " -DSIZE_TYPE="  + OclTypeTraits<SizeType>::type
                 + " -DVALUE_TYPE=" + OclTypeTraits<T>::type
                 + " -DWG_SIZE="    + std::to_string(kernel0_WgSize)
                 + " -D" + ElementWiseOperatorTrait<OP>::operation;
 
+        if(typeid(T) == typeid(cl_double))
+        {
+            params.append(" -DDOUBLE");
+            if (!control->dpfp_support)
+            {
+#ifndef NDEBUG
+                std::cerr << "Failure attempting to run double precision kernel on device without DPFP support." << std::endl;
+#endif
+                return clsparseInvalidDevice;
+            }
+        }
 
         cl::Kernel kernel = KernelCache::get(control->queue, "scan",
                                              "per_block_inclusive_scan", params);
@@ -142,11 +153,23 @@ scan(VectorType& output, const VectorType& input,
 
         SizeType workPerThread = sizeScanBuff / kernel1_WgSize;
 
-        const std::string params = std::string()
+        std::string params = std::string()
                 + " -DSIZE_TYPE="  + OclTypeTraits<SizeType>::type
                 + " -DVALUE_TYPE=" + OclTypeTraits<T>::type
                 + " -DWG_SIZE="    + std::to_string(kernel1_WgSize)
                 + " -D" + ElementWiseOperatorTrait<OP>::operation;
+
+        if(typeid(T) == typeid(cl_double))
+        {
+            params.append(" -DDOUBLE");
+            if (!control->dpfp_support)
+            {
+#ifndef NDEBUG
+                std::cerr << "Failure attempting to run double precision kernel on device without DPFP support." << std::endl;
+#endif
+                return clsparseInvalidDevice;
+            }
+        }
 
         cl::Kernel kernel = KernelCache::get(control->queue, "scan",
                                              "intra_block_inclusive_scan", params);
@@ -176,12 +199,23 @@ scan(VectorType& output, const VectorType& input,
     {
         std::size_t lds = kernel0_WgSize * sizeof(T); //local mem size
 
-        const std::string params = std::string()
+        std::string params = std::string()
                 + " -DSIZE_TYPE="  + OclTypeTraits<SizeType>::type
                 + " -DVALUE_TYPE=" + OclTypeTraits<T>::type
                 + " -DWG_SIZE="    + std::to_string(kernel1_WgSize)
                 + " -D" + ElementWiseOperatorTrait<OP>::operation;
 
+        if(typeid(T) == typeid(cl_double))
+        {
+            params.append(" -DDOUBLE");
+            if (!control->dpfp_support)
+            {
+#ifndef NDEBUG
+                std::cerr << "Failure attempting to run double precision kernel on device without DPFP support." << std::endl;
+#endif
+                return clsparseInvalidDevice;
+            }
+        }
 
         cl::Kernel kernel = KernelCache::get(control->queue, "scan",
                                              "per_block_addition", params);


### PR DESCRIPTION
This fixes #141

Previously, all of our OpenCL kernels blindly included either the extension cl_khr_fp64 or cl_amd_fp64 without checking if the kernel actually needed double precision support. As per Issue #141, this means that our kernels would fail to build when the target device does not include DPFP support.

This patchset does three major things:

* Only includes the fp64 extension pragmas on OpenCL versions earlier than 1.2. As of 1.2, fp64 support is an optional core feature (not an extension). This should silence some compiler warnings.
* Only includes the fp64 extensions if the kernel actually needs support for fp64. My method for doing this was to check on the host side whether one of data types is a double, and passing in -DDOUBLE if so.
  * I would have liked to instead compare VALUE_TYPE (or any of our other *_TYPE constants) against double, but string comparisons in the preprocessor are non-portable
* Adds a bool into the control structure to indicate whether the hardware has double precision support. If we attempt to launch a clSPARSE kernel that requires fp64 on a device that indicates no fp64 support, the function call will fail with the return `clsparseInvalidDevice` and (optionally, in Debug builds) print out a complaint to stderr.

Now with fixes that were suggested in commit #155 