### PR TITLE
Fixes for a series of issues + Print GFLOPs

### DIFF
--- a/src/benchmarks/clsparse-bench/functions/clfunc-xSpMdM.hpp
+++ b/src/benchmarks/clsparse-bench/functions/clfunc-xSpMdM.hpp
@@ -25,7 +25,7 @@ template <typename T>
 class xSpMdM: public clsparseFunc
 {
 public:
-    xSpMdM( PFCLSPARSETIMER sparseGetTimer, size_t profileCount, cl_device_type devType, size_t columns ): clsparseFunc( devType, CL_QUEUE_PROFILING_ENABLE ), gpuTimer( nullptr ), cpuTimer( nullptr ), num_columns( columns )
+    xSpMdM( PFCLSPARSETIMER sparseGetTimer, size_t profileCount, cl_device_type devType, cl_bool explicit_zeroes, size_t columns ): clsparseFunc( devType, CL_QUEUE_PROFILING_ENABLE ), gpuTimer( nullptr ), cpuTimer( nullptr ), num_columns( columns )
     {
         //	Create and initialize our timer class, if the external timer shared library loaded
         if( sparseGetTimer )
@@ -44,6 +44,7 @@ public:
 
 
         clsparseEnableAsync( control, false );
+        clsparseEnableExplicitZeroes( control, explicit_zeroes);
     }
 
     ~xSpMdM( )

--- a/src/benchmarks/clsparse-bench/functions/clfunc_xBiCGStab.hpp
+++ b/src/benchmarks/clsparse-bench/functions/clfunc_xBiCGStab.hpp
@@ -28,7 +28,7 @@ template <typename T>
 class xBiCGStab : public clsparseFunc
 {
 public:
-    xBiCGStab( PFCLSPARSETIMER sparseGetTimer, size_t profileCount, cl_device_type devType ):
+    xBiCGStab( PFCLSPARSETIMER sparseGetTimer, size_t profileCount, cl_bool explicit_zeroes, cl_device_type devType ):
         clsparseFunc( devType, CL_QUEUE_PROFILING_ENABLE ),/* gpuTimer( nullptr ),*/ cpuTimer( nullptr )
     {
         //	Create and initialize our timer class, if the external timer shared library loaded
@@ -48,6 +48,7 @@ public:
 
 
         clsparseEnableAsync( control, false );
+        clsparseEnableExplicitZeroes( control, explicit_zeroes);
 
         solverControl = clsparseCreateSolverControl(DIAGONAL, 1000, 1e-6, 0);
         clsparseSolverPrintMode(solverControl, VERBOSE);

--- a/src/benchmarks/clsparse-bench/functions/clfunc_xCG.hpp
+++ b/src/benchmarks/clsparse-bench/functions/clfunc_xCG.hpp
@@ -26,7 +26,7 @@ template <typename T>
 class xCG : public clsparseFunc
 {
 public:
-    xCG( PFCLSPARSETIMER sparseGetTimer, size_t profileCount, cl_device_type devType ):
+    xCG( PFCLSPARSETIMER sparseGetTimer, size_t profileCount, cl_bool explicit_zeroes, cl_device_type devType ):
         clsparseFunc( devType, CL_QUEUE_PROFILING_ENABLE ),/* gpuTimer( nullptr ),*/ cpuTimer( nullptr )
     {
         //	Create and initialize our timer class, if the external timer shared library loaded
@@ -46,6 +46,7 @@ public:
 
 
         clsparseEnableAsync( control, false );
+        clsparseEnableExplicitZeroes(control, explicit_zeroes);
 
         solverControl = clsparseCreateSolverControl(NOPRECOND, 10000, 1e-4, 1e-8);
         clsparseSolverPrintMode(solverControl, NORMAL);

--- a/src/benchmarks/clsparse-bench/functions/clfunc_xCoo2Csr.hpp
+++ b/src/benchmarks/clsparse-bench/functions/clfunc_xCoo2Csr.hpp
@@ -25,7 +25,7 @@ template <typename T>
 class xCoo2Csr: public clsparseFunc
 {
 public:
-    xCoo2Csr( PFCLSPARSETIMER sparseGetTimer, size_t profileCount, cl_device_type devType ): clsparseFunc( devType, CL_QUEUE_PROFILING_ENABLE ), gpuTimer( nullptr ), cpuTimer( nullptr )
+    xCoo2Csr( PFCLSPARSETIMER sparseGetTimer, size_t profileCount, cl_bool explicit_zeroes, cl_device_type devType ): clsparseFunc( devType, CL_QUEUE_PROFILING_ENABLE ), gpuTimer( nullptr ), cpuTimer( nullptr )
     {
         //	Create and initialize our timer class, if the external timer shared library loaded
         if( sparseGetTimer )
@@ -44,6 +44,7 @@ public:
 
 
         clsparseEnableAsync( control, false );
+        clsparseEnableExplicitZeroes( control, explicit_zeroes);
     }
 
     ~xCoo2Csr( )

--- a/src/benchmarks/clsparse-bench/functions/clfunc_xCsr2Coo.hpp
+++ b/src/benchmarks/clsparse-bench/functions/clfunc_xCsr2Coo.hpp
@@ -26,7 +26,7 @@ template <typename T>
 class xCsr2Coo : public clsparseFunc
 {
 public:
-	xCsr2Coo(PFCLSPARSETIMER sparseGetTimer, size_t profileCount, cl_device_type dev_type) : clsparseFunc(dev_type, CL_QUEUE_PROFILING_ENABLE)
+	xCsr2Coo(PFCLSPARSETIMER sparseGetTimer, size_t profileCount, cl_bool explicit_zeroes, cl_device_type dev_type) : clsparseFunc(dev_type, CL_QUEUE_PROFILING_ENABLE)
 	{
 		gpuTimer = nullptr;
 		cpuTimer = nullptr;
@@ -47,6 +47,7 @@ public:
 		}
 
 		clsparseEnableAsync(control, false);
+                clsparseEnableExplicitZeroes( control, explicit_zeroes);
 	}// End of constructor
 
 	~xCsr2Coo()

--- a/src/benchmarks/clsparse-bench/functions/clfunc_xCsr2Dense.hpp
+++ b/src/benchmarks/clsparse-bench/functions/clfunc_xCsr2Dense.hpp
@@ -26,7 +26,7 @@ template <typename T>
 class xCsr2Dense : public clsparseFunc
 {
 public:
-    xCsr2Dense(PFCLSPARSETIMER sparseGetTimer, size_t profileCount, cl_device_type dev_type) : clsparseFunc(dev_type, CL_QUEUE_PROFILING_ENABLE)
+    xCsr2Dense(PFCLSPARSETIMER sparseGetTimer, size_t profileCount, cl_bool explicit_zeroes, cl_device_type dev_type) : clsparseFunc(dev_type, CL_QUEUE_PROFILING_ENABLE)
     {
         gpuTimer = nullptr;
         cpuTimer = nullptr;
@@ -47,6 +47,7 @@ public:
         }
 
         clsparseEnableAsync(control, false);
+        clsparseEnableExplicitZeroes( control, explicit_zeroes);
     }// End of constructor
 
     ~xCsr2Dense()

--- a/src/benchmarks/clsparse-bench/functions/clfunc_xDense2Csr.hpp
+++ b/src/benchmarks/clsparse-bench/functions/clfunc_xDense2Csr.hpp
@@ -25,7 +25,7 @@ template <typename T>
 class xDense2Csr: public clsparseFunc
 {
 public:
-    xDense2Csr( PFCLSPARSETIMER sparseGetTimer, size_t profileCount, cl_device_type devType ): clsparseFunc( devType, CL_QUEUE_PROFILING_ENABLE ), gpuTimer( nullptr ), cpuTimer( nullptr )
+    xDense2Csr( PFCLSPARSETIMER sparseGetTimer, size_t profileCount, cl_bool explicit_zeroes, cl_device_type devType ): clsparseFunc( devType, CL_QUEUE_PROFILING_ENABLE ), gpuTimer( nullptr ), cpuTimer( nullptr )
     {
 		gpuTimer = nullptr;
 		cpuTimer = nullptr;
@@ -45,6 +45,7 @@ public:
             cpuTimerID = cpuTimer->getUniqueID( "CPU xDense2Csr", 0 );
         }
         clsparseEnableAsync( control, false );
+        clsparseEnableExplicitZeroes( control, explicit_zeroes);
     }// End of constructor
 
     ~xDense2Csr( )

--- a/src/benchmarks/clsparse-bench/functions/clfunc_xSpMSpM.hpp
+++ b/src/benchmarks/clsparse-bench/functions/clfunc_xSpMSpM.hpp
@@ -41,7 +41,7 @@ clsparseStatus clsparseDcsrSpGemm(const clsparseCsrMatrix* sparseMatA, const cls
 template <typename T>
 class xSpMSpM : public clsparseFunc {
 public:
-    xSpMSpM(PFCLSPARSETIMER sparseGetTimer, size_t profileCount, cl_device_type devType) : clsparseFunc(devType, CL_QUEUE_PROFILING_ENABLE), gpuTimer(nullptr), cpuTimer(nullptr)
+    xSpMSpM(PFCLSPARSETIMER sparseGetTimer, size_t profileCount, cl_bool explicit_zeroes, cl_device_type devType) : clsparseFunc(devType, CL_QUEUE_PROFILING_ENABLE), gpuTimer(nullptr), cpuTimer(nullptr)
     {
         //	Create and initialize our timer class, if the external timer shared library loaded
         if (sparseGetTimer)
@@ -58,6 +58,7 @@ public:
             cpuTimerID = cpuTimer->getUniqueID("CPU xSpMSpM", 0);
         }
         clsparseEnableAsync(control, false);
+        clsparseEnableExplicitZeroes( control, explicit_zeroes);
     }
 
     ~xSpMSpM() {}

--- a/src/benchmarks/clsparse-bench/functions/clfunc_xSpMdV.hpp
+++ b/src/benchmarks/clsparse-bench/functions/clfunc_xSpMdV.hpp
@@ -25,7 +25,7 @@ template <typename T>
 class xSpMdV: public clsparseFunc
 {
 public:
-    xSpMdV( PFCLSPARSETIMER sparseGetTimer, size_t profileCount, cl_bool extended_precision, cl_device_type devType ): clsparseFunc( devType, CL_QUEUE_PROFILING_ENABLE ), gpuTimer( nullptr ), cpuTimer( nullptr )
+    xSpMdV( PFCLSPARSETIMER sparseGetTimer, size_t profileCount, cl_bool extended_precision, cl_bool explicit_zeroes, cl_device_type devType ): clsparseFunc( devType, CL_QUEUE_PROFILING_ENABLE ), gpuTimer( nullptr ), cpuTimer( nullptr )
     {
         //	Create and initialize our timer class, if the external timer shared library loaded
         if( sparseGetTimer )
@@ -43,6 +43,7 @@ public:
         }
 
         clsparseEnableExtendedPrecision( control, extended_precision );
+        clsparseEnableExplicitZeroes( control, explicit_zeroes );
 
         clsparseEnableAsync( control, false );
     }

--- a/src/benchmarks/clsparse-bench/functions/clfunc_xSpMdV.hpp
+++ b/src/benchmarks/clsparse-bench/functions/clfunc_xSpMdV.hpp
@@ -71,12 +71,12 @@ public:
 
     double gflops( )
     {
-        return 0.0;
+        return ((2 * csrMtx.num_nonzeros) / time_in_ns ( ));
     }
 
     std::string gflops_formula( )
     {
-        return "N/A";
+        return "GFLOPs";
     }
 
     double bandwidth( )
@@ -207,12 +207,15 @@ public:
         {
           std::cout << "clSPARSE matrix: " << sparseFile << std::endl;
           size_t sparseBytes = sizeof( cl_int )*( csrMtx.num_nonzeros + csrMtx.num_rows ) + sizeof( T ) * ( csrMtx.num_nonzeros + csrMtx.num_cols + csrMtx.num_rows );
+          size_t sparseFlops = 2 * csrMtx.num_nonzeros;
           cpuTimer->pruneOutliers( 3.0 );
           cpuTimer->Print( sparseBytes, "GiB/s" );
+          cpuTimer->Print( sparseFlops, "GFLOPs" );
           cpuTimer->Reset( );
 
           gpuTimer->pruneOutliers( 3.0 );
           gpuTimer->Print( sparseBytes, "GiB/s" );
+          gpuTimer->Print( sparseFlops, "GFLOPs" );
           gpuTimer->Reset( );
         }
 

--- a/src/benchmarks/clsparse-bench/src/main.cpp
+++ b/src/benchmarks/clsparse-bench/src/main.cpp
@@ -130,6 +130,7 @@ int main( int argc, char *argv[ ] )
         ( "precision,r", po::value<std::string>( &precision )->default_value( "s" ), "Options: s,d,c,z" )
         ( "profile,p", po::value<size_t>( &profileCount )->default_value( 20 ), "Number of times to run the desired test function" )
         ( "extended,e", po::bool_switch()->default_value(false), "Use compensated summation to improve accuracy by emulating extended precision" )
+        ( "no_zeroes,z", po::bool_switch()->default_value(false), "Disable reading explicit zeroes from the input matrix market file.")
         ;
 
     po::variables_map vm;
@@ -164,7 +165,10 @@ int main( int argc, char *argv[ ] )
 
     cl_bool extended_precision = false;
     if (vm["extended"].as<bool>())
-                extended_precision = true;
+        extended_precision = true;
+    cl_bool explicit_zeroes = true;
+    if (vm["no_zeroes"].as<bool>())
+        explicit_zeroes = false;
 
     //	Timer module discovered and loaded successfully
     //	Initialize function pointers to call into the shared module
@@ -175,9 +179,9 @@ int main( int argc, char *argv[ ] )
     if( boost::iequals( function, "SpMdV" ) )
     {
         if( precision == "s" )
-            my_function = std::unique_ptr< clsparseFunc >( new xSpMdV< float >( sparseGetTimer, profileCount, extended_precision, CL_DEVICE_TYPE_GPU ) );
+            my_function = std::unique_ptr< clsparseFunc >( new xSpMdV< float >( sparseGetTimer, profileCount, extended_precision, explicit_zeroes, CL_DEVICE_TYPE_GPU ) );
         else if( precision == "d" )
-            my_function = std::unique_ptr< clsparseFunc >( new xSpMdV< double >( sparseGetTimer, profileCount, extended_precision, CL_DEVICE_TYPE_GPU ) );
+            my_function = std::unique_ptr< clsparseFunc >( new xSpMdV< double >( sparseGetTimer, profileCount, extended_precision, explicit_zeroes, CL_DEVICE_TYPE_GPU ) );
         else
         {
             std::cerr << "Unknown spmdv precision" << std::endl;
@@ -187,59 +191,59 @@ int main( int argc, char *argv[ ] )
     else if( boost::iequals( function, "CG" ) )
     {
         if( precision == "s" )
-            my_function = std::unique_ptr< clsparseFunc >( new xCG< float >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU ) );
+            my_function = std::unique_ptr< clsparseFunc >( new xCG< float >( sparseGetTimer, profileCount, explicit_zeroes, CL_DEVICE_TYPE_GPU ) );
         else
-            my_function = std::unique_ptr< clsparseFunc >( new xCG< double >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU ) );
+            my_function = std::unique_ptr< clsparseFunc >( new xCG< double >( sparseGetTimer, profileCount, explicit_zeroes, CL_DEVICE_TYPE_GPU ) );
     }
 
     else if( boost::iequals( function, "BiCGStab" ) )
     {
         if( precision == "s" )
-            my_function = std::unique_ptr< clsparseFunc >( new xBiCGStab< float >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU ) );
+            my_function = std::unique_ptr< clsparseFunc >( new xBiCGStab< float >( sparseGetTimer, profileCount, explicit_zeroes, CL_DEVICE_TYPE_GPU ) );
         else
-            my_function = std::unique_ptr< clsparseFunc >( new xBiCGStab< double >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU ) );
+            my_function = std::unique_ptr< clsparseFunc >( new xBiCGStab< double >( sparseGetTimer, profileCount, explicit_zeroes, CL_DEVICE_TYPE_GPU ) );
     }
     else if( boost::iequals( function, "SpMdM" ) )
     {
         if( precision == "s" )
-            my_function = std::unique_ptr< clsparseFunc >( new xSpMdM< cl_float >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU, columns ) );
+            my_function = std::unique_ptr< clsparseFunc >( new xSpMdM< cl_float >( sparseGetTimer, profileCount, explicit_zeroes, CL_DEVICE_TYPE_GPU, columns ) );
         else
-            my_function = std::unique_ptr< clsparseFunc >( new xSpMdM< cl_double >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU, columns ) );
+            my_function = std::unique_ptr< clsparseFunc >( new xSpMdM< cl_double >( sparseGetTimer, profileCount, explicit_zeroes, CL_DEVICE_TYPE_GPU, columns ) );
     }
     else if (boost::iequals(function, "SpMSpM"))
     {
         if (precision == "s")
-            my_function = std::unique_ptr< clsparseFunc>(new xSpMSpM< cl_float >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU));
+            my_function = std::unique_ptr< clsparseFunc>(new xSpMSpM< cl_float >( sparseGetTimer, profileCount, explicit_zeroes, CL_DEVICE_TYPE_GPU));
         else
-            my_function = std::unique_ptr< clsparseFunc >(new xSpMSpM< cl_double >(sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU));
+            my_function = std::unique_ptr< clsparseFunc >(new xSpMSpM< cl_double >(sparseGetTimer, profileCount, explicit_zeroes,  CL_DEVICE_TYPE_GPU));
     }
     else if( boost::iequals( function, "Coo2Csr" ) )
     {
         if( precision == "s" )
-            my_function = std::unique_ptr< clsparseFunc >( new xCoo2Csr< float >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU ) );
+            my_function = std::unique_ptr< clsparseFunc >( new xCoo2Csr< float >( sparseGetTimer, profileCount, explicit_zeroes, CL_DEVICE_TYPE_GPU ) );
         else
-            my_function = std::unique_ptr< clsparseFunc >( new xCoo2Csr< double >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU ) );
+            my_function = std::unique_ptr< clsparseFunc >( new xCoo2Csr< double >( sparseGetTimer, profileCount, explicit_zeroes, CL_DEVICE_TYPE_GPU ) );
     }
     else if( boost::iequals( function, "Dense2Csr" ) )
     {
         if( precision == "s" )
-            my_function = std::unique_ptr< clsparseFunc >( new xDense2Csr< float >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU ) );
+            my_function = std::unique_ptr< clsparseFunc >( new xDense2Csr< float >( sparseGetTimer, profileCount, explicit_zeroes, CL_DEVICE_TYPE_GPU ) );
         else
-            my_function = std::unique_ptr< clsparseFunc >( new xDense2Csr< double >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU ) );
+            my_function = std::unique_ptr< clsparseFunc >( new xDense2Csr< double >( sparseGetTimer, profileCount, explicit_zeroes, CL_DEVICE_TYPE_GPU ) );
     }
     else if( boost::iequals( function, "Csr2Dense" ) )
     {
         if( precision == "s" )
-            my_function = std::unique_ptr< clsparseFunc >( new xCsr2Dense< cl_float >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU ) );
+            my_function = std::unique_ptr< clsparseFunc >( new xCsr2Dense< cl_float >( sparseGetTimer, profileCount, explicit_zeroes, CL_DEVICE_TYPE_GPU ) );
         else
-            my_function = std::unique_ptr< clsparseFunc >( new xCsr2Dense< cl_double >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU ) );
+            my_function = std::unique_ptr< clsparseFunc >( new xCsr2Dense< cl_double >( sparseGetTimer, profileCount, explicit_zeroes, CL_DEVICE_TYPE_GPU ) );
     }
     else if( boost::iequals( function, "Csr2Coo" ) )
     {
         if( precision == "s" )
-            my_function = std::unique_ptr< clsparseFunc >( new xCsr2Coo< cl_float >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU ) );
+            my_function = std::unique_ptr< clsparseFunc >( new xCsr2Coo< cl_float >( sparseGetTimer, profileCount, explicit_zeroes, CL_DEVICE_TYPE_GPU ) );
         else
-            my_function = std::unique_ptr< clsparseFunc >( new xCsr2Coo< cl_double >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU ) );
+            my_function = std::unique_ptr< clsparseFunc >( new xCsr2Coo< cl_double >( sparseGetTimer, profileCount, explicit_zeroes, CL_DEVICE_TYPE_GPU ) );
     }
     else
     {

--- a/src/benchmarks/cusparse-bench/functions/cufunc_xSpMdV.hpp
+++ b/src/benchmarks/cusparse-bench/functions/cufunc_xSpMdV.hpp
@@ -51,12 +51,12 @@ public:
 
     double gflops( )
     {
-        return 0.0;
+        return ((2 * n_vals) / time_in_ns ( ));
     }
 
     std::string gflops_formula( )
     {
-        return "N/A";
+        return "GFLOPs";
     }
 
     double bandwidth( )

--- a/src/benchmarks/cusparse-bench/src/main.cpp
+++ b/src/benchmarks/cusparse-bench/src/main.cpp
@@ -278,8 +278,10 @@ int main(int argc, char *argv[])
         timer.pruneOutliers( 3.0 );
         std::cout << "cuSPARSE matrix: " << path << std::endl;
         std::cout << "cuSPARSE kernel execution time < ns >: " << my_function->time_in_ns( ) << std::endl;
-        std::cout << "cuSPARSE kernel execution Gflops < " <<
+        std::cout << "cuSPARSE kernel execution < " <<
             my_function->bandwidth_formula( ) << " >: " << my_function->bandwidth( ) << std::endl << std::endl;
+        std::cout << "cuSPARSE kernel execution < " <<
+            my_function->gflops_formula( ) << " >: " << my_function->gflops( ) << std::endl << std::endl;
       }
 
   }

--- a/src/include/clSPARSE.h
+++ b/src/include/clSPARSE.h
@@ -260,6 +260,20 @@ extern "C" {
         clsparseEnableExtendedPrecision( clsparseControl control, cl_bool extPrecision );
 
     /*!
+    * \brief Enable/Disable reading explicit zero values from the matrix market files.
+    *
+    * \param[in] control   A valid clsparseControl created with clsparseCreateControl
+    * \param[in] expZeroes   True to enable reading explicit zeroes, false to skip reading them
+    *
+    * \returns \b clsparseSuccess
+    *
+    * \ingroup STATE
+    */
+    CLSPARSE_EXPORT clsparseStatus
+        clsparseEnableExplicitZeroes( clsparseControl control, cl_bool expZeroes );
+
+
+    /*!
     * \brief Configure the library to use an array of events
     * \warning NOT WORKING! NDRange throws Failure
     *

--- a/src/library/internal/clsparse-control.cpp
+++ b/src/library/internal/clsparse-control.cpp
@@ -114,6 +114,7 @@ clsparseCreateControl( cl_command_queue queue, clsparseStatus *status )
     control->async = false;
     control->extended_precision = false;
     control->dpfp_support = false;
+    control->exp_zeroes = true;
 
     collectEnvParams( control );
 
@@ -163,6 +164,18 @@ clsparseEnableExtendedPrecision( clsparseControl control, cl_bool extended_preci
     }
 
     control->extended_precision = extended_precision;
+    return clsparseSuccess;
+}
+
+clsparseStatus
+clsparseEnableExplicitZeroes( clsparseControl control, cl_bool exp_zeroes )
+{
+    if( control == NULL )
+    {
+        return clsparseInvalidControlObject;
+    }
+
+    control->exp_zeroes = exp_zeroes;
     return clsparseSuccess;
 }
 

--- a/src/library/internal/clsparse-control.hpp
+++ b/src/library/internal/clsparse-control.hpp
@@ -67,6 +67,10 @@ struct _clsparseControl
     //otherwise after every kernel call we are syncing internally;
     cl_bool async;
 
+    // When reading in values from matrix market files, should we store zero values that
+    // are explicit in the file?
+    cl_bool exp_zeroes;
+
     // Handle/pointer to the librar logger
     clsparseDeviceTimer* pDeviceTimer;
 

--- a/src/library/io/mm-reader.cpp
+++ b/src/library/io/mm-reader.cpp
@@ -87,10 +87,10 @@ public:
 
     bool MMReadHeader( FILE* infile );
     bool MMReadHeader( const std::string& filename );
-    bool MMReadFormat( const std::string& _filename );
+    bool MMReadFormat( const std::string& _filename, clsparseControl control );
     int MMReadBanner( FILE* infile );
     int MMReadMtxCrdSize( FILE* infile );
-    void MMGenerateCOOFromFile( FILE* infile );
+    void MMGenerateCOOFromFile( FILE* infile, clsparseControl control );
 
     int GetNumRows( )
     {
@@ -192,7 +192,7 @@ bool MatrixMarketReader<FloatType>::MMReadHeader( const std::string &filename )
 }
 
 template<typename FloatType>
-bool MatrixMarketReader<FloatType>::MMReadFormat( const std::string &filename )
+bool MatrixMarketReader<FloatType>::MMReadFormat( const std::string &filename, clsparseControl control )
 {
     FILE *mm_file = ::fopen( filename.c_str( ), "r" );
     if( mm_file == NULL )
@@ -212,7 +212,7 @@ bool MatrixMarketReader<FloatType>::MMReadFormat( const std::string &filename )
     else
         unsym_coords = new Coordinate<FloatType>[ nNZ ];
 
-    MMGenerateCOOFromFile( mm_file );
+    MMGenerateCOOFromFile( mm_file, control );
     ::fclose( mm_file );
 
     return 0;
@@ -249,13 +249,13 @@ void FillCoordData( char Typecode[ ],
 }
 
 template<typename FloatType>
-void MatrixMarketReader<FloatType>::MMGenerateCOOFromFile( FILE *infile )
+void MatrixMarketReader<FloatType>::MMGenerateCOOFromFile( FILE *infile, clsparseControl control )
 {
     int unsym_actual_nnz = 0;
     FloatType val;
     int ir, ic;
 
-    const int exp_zeroes = 0;
+    const int exp_zeroes = control->exp_zeroes;
 
     //silence warnings from fscanf (-Wunused-result)
     int rv = 0;
@@ -464,7 +464,7 @@ clsparseSCooMatrixfromFile( clsparseCooMatrix* cooMatx, const char* filePath, cl
         return clsparseInvalidFileFormat;
 
     MatrixMarketReader< cl_float > mm_reader;
-    if( mm_reader.MMReadFormat( filePath ) )
+    if( mm_reader.MMReadFormat( filePath, control ) )
         return clsparseInvalidFile;
 
     pCooMatx->num_rows = mm_reader.GetNumRows( );
@@ -514,7 +514,7 @@ clsparseDCooMatrixfromFile( clsparseCooMatrix* cooMatx, const char* filePath, cl
         return clsparseInvalidFileFormat;
 
     MatrixMarketReader< cl_double > mm_reader;
-    if( mm_reader.MMReadFormat( filePath ) )
+    if( mm_reader.MMReadFormat( filePath, control ) )
         return clsparseInvalidFile;
 
     pCooMatx->num_rows = mm_reader.GetNumRows( );
@@ -566,7 +566,7 @@ clsparseSCsrMatrixfromFile(clsparseCsrMatrix* csrMatx, const char* filePath, cls
     // Read data from a file on disk into CPU buffers
     // Data is read natively as COO format with the reader
     MatrixMarketReader< cl_float > mm_reader;
-    if( mm_reader.MMReadFormat( filePath ) )
+    if( mm_reader.MMReadFormat( filePath, control ) )
         return clsparseInvalidFile;
     // BUG: We need to check to see if openCL buffers currently exist and deallocate them first!
     // FIX: Below code will check whether the buffers were allocated in the first place;
@@ -649,7 +649,7 @@ clsparseDCsrMatrixfromFile(clsparseCsrMatrix* csrMatx, const char* filePath, cls
     // Read data from a file on disk into CPU buffers
     // Data is read natively as COO format with the reader
     MatrixMarketReader< cl_double > mm_reader;
-    if( mm_reader.MMReadFormat( filePath ) )
+    if( mm_reader.MMReadFormat( filePath, control ) )
         return clsparseInvalidFile;
 
     // BUG: We need to check to see if openCL buffers currently exist and deallocate them first!
@@ -755,7 +755,7 @@ clsparseDCsrMatrixfromFile(clsparseCsrMatrix* csrMatx, const char* filePath, cls
 //    // Read data from a file on disk into CPU buffers
 //    // Data is read natively as COO format with the reader
 //    MatrixMarketReader< cl_float > mm_reader;
-//    if( mm_reader.MMReadFormat( filePath ) )
+//    if( mm_reader.MMReadFormat( filePath, control ) )
 //        return clsparseInvalidFile;
 
 //    // BUG: We need to check to see if openCL buffers currently exist and deallocate them first!

--- a/src/library/io/mm-reader.cpp
+++ b/src/library/io/mm-reader.cpp
@@ -568,7 +568,6 @@ clsparseSCsrMatrixfromFile(clsparseCsrMatrix* csrMatx, const char* filePath, cls
     MatrixMarketReader< cl_float > mm_reader;
     if( mm_reader.MMReadFormat( filePath ) )
         return clsparseInvalidFile;
-#if 0
     // BUG: We need to check to see if openCL buffers currently exist and deallocate them first!
     // FIX: Below code will check whether the buffers were allocated in the first place;
     {
@@ -590,7 +589,6 @@ clsparseSCsrMatrixfromFile(clsparseCsrMatrix* csrMatx, const char* filePath, cls
         if (validationStatus != clsparseSuccess)
             return validationStatus;
     }
-#endif
 
     // JPA: Shouldn't that just be an assertion check? It seems to me that
     // the user have to call clsparseHeaderfromFile before calling this function,

--- a/src/library/kernels/atomic_reduce.cl
+++ b/src/library/kernels/atomic_reduce.cl
@@ -35,10 +35,10 @@ R"(
   #endif
 #endif
 
-#if defined(ATOMIC_FLOAT) || defined (ATOMIC_INT)
+#if __OPENCL_VERSION__ <= CL_VERSION_1_0 && (defined(ATOMIC_FLOAT) || defined (ATOMIC_INT))
   #if defined(cl_khr_global_int32_base_atomics) && defined(cl_khr_global_int32_extended_atomics)
-    #pragma OPENCL EXTENSION cl_khr_global_int32_base_atomics : require
-    #pragma OPENCL_EXTENSION cl_khr_global_int32_extended_atomics : require
+    #pragma OPENCL EXTENSION cl_khr_global_int32_base_atomics : enable
+    #pragma OPENCL_EXTENSION cl_khr_global_int32_extended_atomics : enable
   #else
     #error "Required 32-bit atomics not supported by this OpenCL implemenation."
   #endif

--- a/src/library/kernels/csrmm_adaptive.cl
+++ b/src/library/kernels/csrmm_adaptive.cl
@@ -42,8 +42,8 @@ R"(
 #if __OPENCL_VERSION__ > CL_VERSION_1_0
   #define ATOM32
 #elif defined(cl_khr_global_int32_base_atomics) && defined(cl_khr_global_int32_extended_atomics)
-  #pragma OPENCL EXTENSION cl_khr_global_int32_base_atomics : require
-  #pragma OPENCL_EXTENSION cl_khr_global_int32_extended_atomics : require
+  #pragma OPENCL EXTENSION cl_khr_global_int32_base_atomics : enable
+  #pragma OPENCL_EXTENSION cl_khr_global_int32_extended_atomics : enable
   #define ATOM32
 #else
   #error "Required integer atomics not supported by this OpenCL implemenation."

--- a/src/library/kernels/csrmv_adaptive.cl
+++ b/src/library/kernels/csrmv_adaptive.cl
@@ -35,8 +35,8 @@ R"(
 #if __OPENCL_VERSION__ > CL_VERSION_1_0
   #define ATOM32
 #elif defined(cl_khr_global_int32_base_atomics) && defined(cl_khr_global_int32_extended_atomics)
-  #pragma OPENCL EXTENSION cl_khr_global_int32_base_atomics : require
-  #pragma OPENCL_EXTENSION cl_khr_global_int32_extended_atomics : require
+  #pragma OPENCL EXTENSION cl_khr_global_int32_base_atomics : enable
+  #pragma OPENCL_EXTENSION cl_khr_global_int32_extended_atomics : enable
   #define ATOM32
 #else
   #error "Required integer atomics not supported by this OpenCL implemenation."

--- a/src/tests/test-blas2.cpp
+++ b/src/tests/test-blas2.cpp
@@ -35,6 +35,7 @@ cl_command_queue ClSparseEnvironment::queue = NULL;
 cl_context ClSparseEnvironment::context = NULL;
 //cl_uint ClSparseEnvironment::N = 1024;
 static cl_bool extended_precision = false;
+static cl_bool explicit_zeroes = true;
 
 namespace po = boost::program_options;
 namespace uBLAS = boost::numeric::ublas;
@@ -133,8 +134,7 @@ public:
         clsparseStatus status;
         cl_int cl_status;
 
-        if (extended_precision)
-            clsparseEnableExtendedPrecision(CLSE::control, true);
+        clsparseEnableExtendedPrecision(CLSE::control, extended_precision);
 
         if (typeid(T) == typeid(cl_float) )
         {
@@ -417,7 +417,10 @@ int main (int argc, char* argv[])
              "Alpha parameter for eq: \n\ty = alpha * M * x + beta * y")
             ("beta,b", po::value(&beta)->default_value(1.0),
              "Beta parameter for eq: \n\ty = alpha * M * x + beta * y")
-            ("extended,e", po::bool_switch()->default_value(false), "Use compensated summation to improve accuracy by emulating extended precision.");
+            ("extended,e", po::bool_switch()->default_value(false),
+             "Use compensated summation to improve accuracy by emulating extended precision.")
+            ("no_zeroes,z", po::bool_switch()->default_value(false),
+             "Disable reading explicit zeroes from the input matrix market file.");
 
     po::variables_map vm;
     po::parsed_options parsed =
@@ -463,10 +466,13 @@ int main (int argc, char* argv[])
 
     if (vm["extended"].as<bool>())
         extended_precision = true;
+    if (vm["no_zeroes"].as<bool>())
+        explicit_zeroes = false;
 
     ::testing::InitGoogleTest(&argc, argv);
     //order does matter!
     ::testing::AddGlobalTestEnvironment( new CLSE(pID, dID));
+    clsparseEnableExplicitZeroes(CLSE::control, explicit_zeroes);
     ::testing::AddGlobalTestEnvironment( new CSRE(path, alpha, beta,
                                                   CLSE::queue, CLSE::context));
 

--- a/src/tests/test-blas3.cpp
+++ b/src/tests/test-blas3.cpp
@@ -48,6 +48,7 @@ clsparseControl ClSparseEnvironment::control = NULL;
 cl_command_queue ClSparseEnvironment::queue = NULL;
 cl_context ClSparseEnvironment::context = NULL;
 
+static cl_bool explicit_zeroes = true;
 
 namespace po = boost::program_options;
 namespace uBLAS = boost::numeric::ublas;
@@ -666,7 +667,9 @@ int main (int argc, char* argv[])
             ("cols,c", po::value(&B_num_cols)->default_value(8),
              "Number of columns in B matrix while calculating sp_A * d_B = d_C")
             ("vals,v", po::value(&B_values)->default_value(1.0),
-             "Initial value of B columns");
+             "Initial value of B columns")
+            ("no_zeroes,z", po::bool_switch()->default_value(false),
+             "Disable reading explicit zeroes from the input matrix market file.");
 
 
     //	Parse the command line options, ignore unrecognized options and collect them into a vector of strings
@@ -709,6 +712,9 @@ int main (int argc, char* argv[])
         }
     }
 
+    if (vm["no_zeroes"].as<bool>())
+        explicit_zeroes = false;
+
     if (boost::iequals(function, "SpMdM"))
     {
         std::cout << "SpMdM Testing \n";
@@ -718,6 +724,7 @@ int main (int argc, char* argv[])
         ::testing::InitGoogleTest(&argc, argv);
         //order does matter!
         ::testing::AddGlobalTestEnvironment(new CLSE(pID, dID));
+        clsparseEnableExplicitZeroes(CLSE::control, explicit_zeroes);
         ::testing::AddGlobalTestEnvironment(new CSRE(path, alpha, beta,
             CLSE::queue, CLSE::context));
 
@@ -731,6 +738,7 @@ int main (int argc, char* argv[])
         ::testing::InitGoogleTest(&argc, argv);
 
         ::testing::AddGlobalTestEnvironment(new CLSE(pID, dID));
+        clsparseEnableExplicitZeroes(CLSE::control, explicit_zeroes);
         ::testing::AddGlobalTestEnvironment(new SPER(path, CLSE::queue, CLSE::context));
     }
     else if (boost::iequals(function, "All"))
@@ -738,6 +746,7 @@ int main (int argc, char* argv[])
         ::testing::InitGoogleTest(&argc, argv);
         //order does matter!
         ::testing::AddGlobalTestEnvironment(new CLSE(pID, dID));
+        clsparseEnableExplicitZeroes(CLSE::control, explicit_zeroes);
         ::testing::AddGlobalTestEnvironment(new CSRE(path, alpha, beta,
             CLSE::queue, CLSE::context));
         ::testing::AddGlobalTestEnvironment(new SPER(path, CLSE::queue, CLSE::context));

--- a/src/tests/test-conversion.cpp
+++ b/src/tests/test-conversion.cpp
@@ -42,6 +42,8 @@ clsparseControl ClSparseEnvironment::control = NULL;
 cl_command_queue ClSparseEnvironment::queue = NULL;
 cl_context ClSparseEnvironment::context = NULL;
 
+static cl_bool explicit_zeroes = true;
+
 namespace po = boost::program_options;
 namespace uBLAS = boost::numeric::ublas;
 
@@ -654,7 +656,9 @@ int main (int argc, char* argv[])
             ("platform,l", po::value(&platform)->default_value("AMD"),
              "OpenCL platform: AMD or NVIDIA.")
             ("device,d", po::value(&dID)->default_value(0),
-             "Device id within platform.");
+             "Device id within platform.")
+            ("no_zeroes,z", po::bool_switch()->default_value(false),
+             "Disable reading explicit zeroes from the input matrix market file.");
 
     //	Parse the command line options, ignore unrecognized options and collect them into a vector of strings
     //  Googletest itself accepts command line flags that we wish to pass further on
@@ -698,9 +702,13 @@ int main (int argc, char* argv[])
 
     }
 
+    if (vm["no_zeroes"].as<bool>())
+        explicit_zeroes = false;
+
     ::testing::InitGoogleTest(&argc, argv);
     //order does matter!
     ::testing::AddGlobalTestEnvironment( new CLSE(pID, dID));
+    clsparseEnableExplicitZeroes(CLSE::control, explicit_zeroes);
     ::testing::AddGlobalTestEnvironment( new CSRE(path, 1, 0,
                                                   CLSE::queue, CLSE::context));
     return RUN_ALL_TESTS();

--- a/src/tests/test-solvers.cpp
+++ b/src/tests/test-solvers.cpp
@@ -43,6 +43,7 @@ cl_command_queue ClSparseEnvironment::queue = NULL;
 cl_context ClSparseEnvironment::context = NULL;
 //cl_uint ClSparseEnvironment::N = 1024;
 
+static cl_bool explicit_zeroes = true;
 
 namespace po = boost::program_options;
 namespace uBLAS = boost::numeric::ublas;
@@ -276,7 +277,9 @@ int main (int argc, char* argv[])
             ("initx,x", po::value(&initialUnknownsValue)->default_value(0),
              "Initial value for vector of unknowns")
             ("initb,b", po::value(&initialRhsValue)->default_value(1),
-             "Initial value for rhs vector");
+             "Initial value for rhs vector")
+            ("no_zeroes,z", po::bool_switch()->default_value(false),
+             "Disable reading explicit zeroes from the input matrix market file.");
 
 
     po::variables_map vm;
@@ -321,6 +324,9 @@ int main (int argc, char* argv[])
 
     }
 
+    if (vm["no_zeroes"].as<bool>())
+        explicit_zeroes = false;
+
     //pickup preconditioner
     if ( boost::iequals(strPrecond, "Diagonal"))
     {
@@ -362,6 +368,7 @@ int main (int argc, char* argv[])
     ::testing::InitGoogleTest(&argc, argv);
     //order does matter!
     ::testing::AddGlobalTestEnvironment( new CLSE(pID, dID));
+    clsparseEnableExplicitZeroes(CLSE::control, explicit_zeroes);
     ::testing::AddGlobalTestEnvironment( new CSRE(path, 0, 0,
                                                   CLSE::queue, CLSE::context));
 

--- a/src/tests/test_readMMcoo.cpp
+++ b/src/tests/test_readMMcoo.cpp
@@ -28,6 +28,8 @@ clsparseControl ClSparseEnvironment::control = NULL;
 cl_command_queue ClSparseEnvironment::queue = NULL;
 cl_context ClSparseEnvironment::context = NULL;
 
+static cl_bool explicit_zeroes = true;
+
 /** Just a simple test checking if the io functions for matrices are ok */
 
 namespace po = boost::program_options;
@@ -150,7 +152,9 @@ int main( int argc, char* argv[ ] )
     desc.add_options( )
         ( "help,h", "Produce this message." )
         ( "path,p", po::value( &path )->required( ),
-        "Path to matrix in mtx format." );
+        "Path to matrix in mtx format." )
+        ("no_zeroes,z", po::bool_switch()->default_value(false),
+         "Disable reading explicit zeroes from the input matrix market file.");
 
     po::variables_map vm;
     try
@@ -165,6 +169,9 @@ int main( int argc, char* argv[ ] )
         return false;
     }
 
+    if (vm["no_zeroes"].as<bool>())
+        explicit_zeroes = false;
+
     double alpha = 1.0;
     double beta = 1.0;
 
@@ -172,6 +179,7 @@ int main( int argc, char* argv[ ] )
 
     //order does matter!
     ::testing::AddGlobalTestEnvironment( new CLSE( ) );
+    clsparseEnableExplicitZeroes(CLSE::control, explicit_zeroes);
     ::testing::AddGlobalTestEnvironment( new CSRE( path, alpha, beta,
         CLSE::queue, CLSE::context ) );
 


### PR DESCRIPTION
This patchset fixes issues: #146 and #161. It also reverts the problem raised in [this discussion](https://github.com/clMathLibraries/clSPARSE/pull/150#discussion_r40400014).

To fix #146, I've added another variable to the control structure that controls whether explicit zero values are read in from the matrix market reader. I've changed the default such that we **do** read the zero values (as discussed in #144). Calling '-z' on many of our test applications now **disables** reading of explicit zeroes. I have not changed our sample applications.

The fix for #161 is as discussed in the issue.

Finally, I've changed the benchmarking code for SpMdV slightly. It now, in addition to printing out the bandwidth in GiB/s, prints out the canonical GFLOPs calculation (where the number of FLOPs is 2 * NNZ).

The GFLOPs calculation is not entirely correct when alpha !=1 and beta !=0, but the calculation as written is used in almost every academic study of SpMdV. Solely presenting GiB/s makes it difficult for people to compare results with clSPARSE. We could make the calculation more complex by special-casing the calculation when alpha and beta are different, but this seems decent enough for now (IMO).