### PR TITLE
Fix for #161 + Print GFLOPs

### DIFF
--- a/src/benchmarks/clsparse-bench/functions/clfunc_xSpMdV.hpp
+++ b/src/benchmarks/clsparse-bench/functions/clfunc_xSpMdV.hpp
@@ -71,12 +71,12 @@ public:
 
     double gflops( )
     {
-        return 0.0;
+        return ((2 * csrMtx.num_nonzeros) / time_in_ns ( ));
     }
 
     std::string gflops_formula( )
     {
-        return "N/A";
+        return "GFLOPs";
     }
 
     double bandwidth( )
@@ -207,12 +207,15 @@ public:
         {
           std::cout << "clSPARSE matrix: " << sparseFile << std::endl;
           size_t sparseBytes = sizeof( cl_int )*( csrMtx.num_nonzeros + csrMtx.num_rows ) + sizeof( T ) * ( csrMtx.num_nonzeros + csrMtx.num_cols + csrMtx.num_rows );
+          size_t sparseFlops = 2 * csrMtx.num_nonzeros;
           cpuTimer->pruneOutliers( 3.0 );
           cpuTimer->Print( sparseBytes, "GiB/s" );
+          cpuTimer->Print( sparseFlops, "GFLOPs" );
           cpuTimer->Reset( );
 
           gpuTimer->pruneOutliers( 3.0 );
           gpuTimer->Print( sparseBytes, "GiB/s" );
+          gpuTimer->Print( sparseFlops, "GFLOPs" );
           gpuTimer->Reset( );
         }
 

--- a/src/benchmarks/cusparse-bench/functions/cufunc_xSpMdV.hpp
+++ b/src/benchmarks/cusparse-bench/functions/cufunc_xSpMdV.hpp
@@ -51,12 +51,12 @@ public:
 
     double gflops( )
     {
-        return 0.0;
+        return ((2 * n_vals) / time_in_ns ( ));
     }
 
     std::string gflops_formula( )
     {
-        return "N/A";
+        return "GFLOPs";
     }
 
     double bandwidth( )

--- a/src/benchmarks/cusparse-bench/src/main.cpp
+++ b/src/benchmarks/cusparse-bench/src/main.cpp
@@ -278,8 +278,10 @@ int main(int argc, char *argv[])
         timer.pruneOutliers( 3.0 );
         std::cout << "cuSPARSE matrix: " << path << std::endl;
         std::cout << "cuSPARSE kernel execution time < ns >: " << my_function->time_in_ns( ) << std::endl;
-        std::cout << "cuSPARSE kernel execution Gflops < " <<
+        std::cout << "cuSPARSE kernel execution < " <<
             my_function->bandwidth_formula( ) << " >: " << my_function->bandwidth( ) << std::endl << std::endl;
+        std::cout << "cuSPARSE kernel execution < " <<
+            my_function->gflops_formula( ) << " >: " << my_function->gflops( ) << std::endl << std::endl;
       }
 
   }

--- a/src/library/io/mm-reader.cpp
+++ b/src/library/io/mm-reader.cpp
@@ -568,7 +568,6 @@ clsparseSCsrMatrixfromFile(clsparseCsrMatrix* csrMatx, const char* filePath, cls
     MatrixMarketReader< cl_float > mm_reader;
     if( mm_reader.MMReadFormat( filePath ) )
         return clsparseInvalidFile;
-#if 0
     // BUG: We need to check to see if openCL buffers currently exist and deallocate them first!
     // FIX: Below code will check whether the buffers were allocated in the first place;
     {
@@ -590,7 +589,6 @@ clsparseSCsrMatrixfromFile(clsparseCsrMatrix* csrMatx, const char* filePath, cls
         if (validationStatus != clsparseSuccess)
             return validationStatus;
     }
-#endif
 
     // JPA: Shouldn't that just be an assertion check? It seems to me that
     // the user have to call clsparseHeaderfromFile before calling this function,

--- a/src/library/kernels/atomic_reduce.cl
+++ b/src/library/kernels/atomic_reduce.cl
@@ -35,10 +35,10 @@ R"(
   #endif
 #endif
 
-#if defined(ATOMIC_FLOAT) || defined (ATOMIC_INT)
+#if __OPENCL_VERSION__ <= CL_VERSION_1_0 && (defined(ATOMIC_FLOAT) || defined (ATOMIC_INT))
   #if defined(cl_khr_global_int32_base_atomics) && defined(cl_khr_global_int32_extended_atomics)
-    #pragma OPENCL EXTENSION cl_khr_global_int32_base_atomics : require
-    #pragma OPENCL_EXTENSION cl_khr_global_int32_extended_atomics : require
+    #pragma OPENCL EXTENSION cl_khr_global_int32_base_atomics : enable
+    #pragma OPENCL_EXTENSION cl_khr_global_int32_extended_atomics : enable
   #else
     #error "Required 32-bit atomics not supported by this OpenCL implemenation."
   #endif

--- a/src/library/kernels/csrmm_adaptive.cl
+++ b/src/library/kernels/csrmm_adaptive.cl
@@ -42,8 +42,8 @@ R"(
 #if __OPENCL_VERSION__ > CL_VERSION_1_0
   #define ATOM32
 #elif defined(cl_khr_global_int32_base_atomics) && defined(cl_khr_global_int32_extended_atomics)
-  #pragma OPENCL EXTENSION cl_khr_global_int32_base_atomics : require
-  #pragma OPENCL_EXTENSION cl_khr_global_int32_extended_atomics : require
+  #pragma OPENCL EXTENSION cl_khr_global_int32_base_atomics : enable
+  #pragma OPENCL_EXTENSION cl_khr_global_int32_extended_atomics : enable
   #define ATOM32
 #else
   #error "Required integer atomics not supported by this OpenCL implemenation."

--- a/src/library/kernels/csrmv_adaptive.cl
+++ b/src/library/kernels/csrmv_adaptive.cl
@@ -35,8 +35,8 @@ R"(
 #if __OPENCL_VERSION__ > CL_VERSION_1_0
   #define ATOM32
 #elif defined(cl_khr_global_int32_base_atomics) && defined(cl_khr_global_int32_extended_atomics)
-  #pragma OPENCL EXTENSION cl_khr_global_int32_base_atomics : require
-  #pragma OPENCL_EXTENSION cl_khr_global_int32_extended_atomics : require
+  #pragma OPENCL EXTENSION cl_khr_global_int32_base_atomics : enable
+  #pragma OPENCL_EXTENSION cl_khr_global_int32_extended_atomics : enable
   #define ATOM32
 #else
   #error "Required integer atomics not supported by this OpenCL implemenation."


### PR DESCRIPTION
As per the discussion in #163, this patchset fixes issue #161. It also reverts the problem raised in [this discussion](https://github.com/clMathLibraries/clSPARSE/pull/150#discussion_r40400014).

I've also changed the benchmarking code for SpMdV slightly. It now, in addition to printing out the bandwidth in GiB/s, prints out the canonical GFLOPs calculation (where the number of FLOPs is 2 * NNZ).

The GFLOPs calculation is not entirely correct when alpha !=1 and beta !=0, but the calculation as written is used in almost every academic study of SpMdV. Solely presenting GiB/s makes it difficult for people to compare results with clSPARSE. We could make the calculation more complex by special-casing the calculation when alpha and beta are different, but this seems decent enough for now (IMO).