### PR TITLE
Dense2Csr conversion fix and acceleration of conversion test.

### DIFF
--- a/src/library/transform/clsparse-dense2csr.cpp
+++ b/src/library/transform/clsparse-dense2csr.cpp
@@ -155,7 +155,7 @@ clsparseDdense2csr(const cldenseMatrix* A,
     if (status != clsparseSuccess)
         return clsparseInvalidKernelExecution;
 
-    status = clsparseScoo2csr(&coo, csr, control);
+    status = clsparseDcoo2csr(&coo, csr, control);
 
 
     clReleaseMemObject(coo.values);


### PR DESCRIPTION
Changed the CSR-to-COO functions to remove uBLAS, which is running much slower than a simple manual conversion. Without this change, it takes multiple minutes to test a small matrix; it takes <100ms afterwards.

Also fixed an error in the Dense-to-CSR conversion routine that meant we were only converting the first half of the matrix when working on double precision.