### PR TITLE
Fix for test-blas3

### DIFF
--- a/src/tests/resources/csr_matrix_environment.h
+++ b/src/tests/resources/csr_matrix_environment.h
@@ -72,9 +72,6 @@ public:
         csrDMatrix.rowOffsets = ::clCreateBuffer( context, CL_MEM_READ_ONLY,
                                                   ( csrDMatrix.num_rows + 1 ) * sizeof( cl_int ), NULL, &status );
 
-        csrDMatrix.rowBlocks = ::clCreateBuffer( context, CL_MEM_READ_WRITE,
-                                                 csrDMatrix.rowBlockSize * sizeof( cl_ulong ), NULL, &status );
-
         clsparseStatus fileError = clsparseDCsrMatrixfromFile( &csrDMatrix, file_name.c_str( ), CLSE::control );
         if( fileError != clsparseSuccess )
             throw std::runtime_error( "Could not read matrix market data from disk: " + file_name );

--- a/src/tests/resources/sparse_matrix_environment.h
+++ b/src/tests/resources/sparse_matrix_environment.h
@@ -57,7 +57,6 @@ public:
         csrSMatrix.num_nonzeros = n_vals;
         csrSMatrix.num_rows = n_rows;
         csrSMatrix.num_cols = n_cols;
-        clsparseCsrMetaSize(&csrSMatrix, CLSE::control);
 
         //  Load single precision data from file; this API loads straight into GPU memory
         cl_int status;
@@ -70,12 +69,14 @@ public:
         csrSMatrix.rowOffsets = ::clCreateBuffer(context, CL_MEM_READ_ONLY,
             (csrSMatrix.num_rows + 1) * sizeof(cl_int), NULL, &status);
 
-        csrSMatrix.rowBlocks = ::clCreateBuffer(context, CL_MEM_READ_ONLY,
-            csrSMatrix.rowBlockSize * sizeof(cl_ulong), NULL, &status);
-
         clsparseStatus fileError = clsparseSCsrMatrixfromFile(&csrSMatrix, file_name.c_str(), CLSE::control);
         if (fileError != clsparseSuccess)
             throw std::runtime_error("Could not read matrix market data from disk");
+
+        clsparseCsrMetaSize(&csrSMatrix, CLSE::control);
+        csrSMatrix.rowBlocks = ::clCreateBuffer( context, CL_MEM_READ_WRITE,
+            csrSMatrix.rowBlockSize * sizeof( cl_ulong ), NULL, &status );
+        clsparseCsrMetaCompute( &csrSMatrix, CLSE::control );
 
         //  Download sparse matrix data to host
         //  First, create space on host to hold the data


### PR DESCRIPTION
Fixes to test-blas3. It was calling the CSR meta-generation functions at the wrong time, resulting in a segfault.