### PR TITLE
Read explicit zeroes from Matrix Market files

### DIFF
--- a/samples/sample-cg.cpp
+++ b/samples/sample-cg.cpp
@@ -195,7 +195,8 @@ int main (int argc, char* argv[])
                                     A.rowBlockSize * sizeof( cl_ulong ), NULL, &cl_status );
 
 
-    fileError = clsparseSCsrMatrixfromFile( &A, matrix_path.c_str( ), control );
+    // Read matrix market file with explicit zero values included.
+    fileError = clsparseSCsrMatrixfromFile( &A, matrix_path.c_str( ), control, true );
 
     // This function allocates memory for rowBlocks structure. If not called
     // the structure will not be calculated and clSPARSE will run the vectorized

--- a/samples/sample-spmv.cpp
+++ b/samples/sample-spmv.cpp
@@ -227,7 +227,8 @@ int main (int argc, char* argv[])
                                     A.rowBlockSize * sizeof( cl_ulong ), NULL, &cl_status );
 
 
-    fileError = clsparseSCsrMatrixfromFile( &A, matrix_path.c_str( ), control );
+    // Read matrix market file with explicit zero values included.
+    fileError = clsparseSCsrMatrixfromFile( &A, matrix_path.c_str( ), control, true );
 
     // This function allocates memory for rowBlocks structure. If not called
     // the structure will not be calculated and clSPARSE will run the vectorized

--- a/src/benchmarks/clsparse-bench/functions/clfunc-xSpMdM.hpp
+++ b/src/benchmarks/clsparse-bench/functions/clfunc-xSpMdM.hpp
@@ -25,7 +25,7 @@ template <typename T>
 class xSpMdM: public clsparseFunc
 {
 public:
-    xSpMdM( PFCLSPARSETIMER sparseGetTimer, size_t profileCount, cl_device_type devType, size_t columns ): clsparseFunc( devType, CL_QUEUE_PROFILING_ENABLE ), gpuTimer( nullptr ), cpuTimer( nullptr ), num_columns( columns )
+    xSpMdM( PFCLSPARSETIMER sparseGetTimer, size_t profileCount, cl_device_type devType, size_t columns, cl_bool keep_explicit_zeroes = true ): clsparseFunc( devType, CL_QUEUE_PROFILING_ENABLE ), gpuTimer( nullptr ), cpuTimer( nullptr ), num_columns( columns )
     {
         //	Create and initialize our timer class, if the external timer shared library loaded
         if( sparseGetTimer )
@@ -44,6 +44,7 @@ public:
 
 
         clsparseEnableAsync( control, false );
+        explicit_zeroes = keep_explicit_zeroes;
     }
 
     ~xSpMdM( )
@@ -124,7 +125,7 @@ public:
         csrMtx.rowOffsets = ::clCreateBuffer( ctx, CL_MEM_READ_ONLY, ( csrMtx.num_rows + 1 ) * sizeof( cl_int ), NULL, &status );
         CLSPARSE_V( status, "::clCreateBuffer csrMtx.rowOffsets" );
 
-        fileError = clsparseSCsrMatrixfromFile( &csrMtx, sparseFile.c_str( ), control );
+        fileError = clsparseSCsrMatrixfromFile( &csrMtx, sparseFile.c_str( ), control, explicit_zeroes );
         if( fileError != clsparseSuccess )
             throw std::runtime_error( "Could not read matrix market data from disk: " + sparseFile);
 
@@ -247,6 +248,7 @@ private:
     T alpha;
     T beta;
     size_t num_columns;
+    cl_bool explicit_zeroes;
 
     //  OpenCL state
     cl_command_queue_properties cqProp;

--- a/src/benchmarks/clsparse-bench/functions/clfunc_xBiCGStab.hpp
+++ b/src/benchmarks/clsparse-bench/functions/clfunc_xBiCGStab.hpp
@@ -28,7 +28,7 @@ template <typename T>
 class xBiCGStab : public clsparseFunc
 {
 public:
-    xBiCGStab( PFCLSPARSETIMER sparseGetTimer, size_t profileCount, cl_device_type devType ):
+    xBiCGStab( PFCLSPARSETIMER sparseGetTimer, size_t profileCount, cl_device_type devType, cl_bool keep_explicit_zeroes = true ):
         clsparseFunc( devType, CL_QUEUE_PROFILING_ENABLE ),/* gpuTimer( nullptr ),*/ cpuTimer( nullptr )
     {
         //	Create and initialize our timer class, if the external timer shared library loaded
@@ -48,6 +48,7 @@ public:
 
 
         clsparseEnableAsync( control, false );
+        explicit_zeroes = keep_explicit_zeroes;
 
         solverControl = clsparseCreateSolverControl(DIAGONAL, 1000, 1e-6, 0);
         clsparseSolverPrintMode(solverControl, VERBOSE);
@@ -130,9 +131,9 @@ public:
         CLSPARSE_V( status, "::clCreateBuffer csrMtx.rowOffsets" );
 
         if(typeid(T) == typeid(float))
-            fileError = clsparseSCsrMatrixfromFile( &csrMtx, sparseFile.c_str( ), control );
+            fileError = clsparseSCsrMatrixfromFile( &csrMtx, sparseFile.c_str( ), control, explicit_zeroes );
         else if (typeid(T) == typeid(double))
-            fileError = clsparseDCsrMatrixfromFile( &csrMtx, sparseFile.c_str( ), control );
+            fileError = clsparseDCsrMatrixfromFile( &csrMtx, sparseFile.c_str( ), control, explicit_zeroes );
         else
             fileError = clsparseInvalidType;
 
@@ -241,6 +242,8 @@ private:
     cldenseVector x;
     cldenseVector y;
 
+    // host values
+    cl_bool explicit_zeroes;
 
     //  OpenCL state
     cl_command_queue_properties cqProp;

--- a/src/benchmarks/clsparse-bench/functions/clfunc_xCG.hpp
+++ b/src/benchmarks/clsparse-bench/functions/clfunc_xCG.hpp
@@ -26,7 +26,7 @@ template <typename T>
 class xCG : public clsparseFunc
 {
 public:
-    xCG( PFCLSPARSETIMER sparseGetTimer, size_t profileCount, cl_device_type devType ):
+    xCG( PFCLSPARSETIMER sparseGetTimer, size_t profileCount, cl_device_type devType, cl_bool keep_explicit_zeroes = true ):
         clsparseFunc( devType, CL_QUEUE_PROFILING_ENABLE ),/* gpuTimer( nullptr ),*/ cpuTimer( nullptr )
     {
         //	Create and initialize our timer class, if the external timer shared library loaded
@@ -46,6 +46,7 @@ public:
 
 
         clsparseEnableAsync( control, false );
+        explicit_zeroes = keep_explicit_zeroes;
 
         solverControl = clsparseCreateSolverControl(NOPRECOND, 10000, 1e-4, 1e-8);
         clsparseSolverPrintMode(solverControl, NORMAL);
@@ -129,9 +130,9 @@ public:
         CLSPARSE_V( status, "::clCreateBuffer csrMtx.rowOffsets" );
 
         if(typeid(T) == typeid(float))
-            fileError = clsparseSCsrMatrixfromFile( &csrMtx, sparseFile.c_str( ), control );
+            fileError = clsparseSCsrMatrixfromFile( &csrMtx, sparseFile.c_str( ), control, explicit_zeroes );
         else if (typeid(T) == typeid(double))
-            fileError = clsparseDCsrMatrixfromFile( &csrMtx, sparseFile.c_str( ), control );
+            fileError = clsparseDCsrMatrixfromFile( &csrMtx, sparseFile.c_str( ), control, explicit_zeroes );
         else
             fileError = clsparseInvalidType;
 
@@ -240,6 +241,8 @@ private:
     cldenseVector x;
     cldenseVector y;
 
+    // host values
+    cl_bool explicit_zeroes;
 
     //  OpenCL state
     cl_command_queue_properties cqProp;

--- a/src/benchmarks/clsparse-bench/functions/clfunc_xCoo2Csr.hpp
+++ b/src/benchmarks/clsparse-bench/functions/clfunc_xCoo2Csr.hpp
@@ -25,7 +25,7 @@ template <typename T>
 class xCoo2Csr: public clsparseFunc
 {
 public:
-    xCoo2Csr( PFCLSPARSETIMER sparseGetTimer, size_t profileCount, cl_device_type devType ): clsparseFunc( devType, CL_QUEUE_PROFILING_ENABLE ), gpuTimer( nullptr ), cpuTimer( nullptr )
+    xCoo2Csr( PFCLSPARSETIMER sparseGetTimer, size_t profileCount, cl_device_type devType, cl_bool keep_explicit_zeroes = true ): clsparseFunc( devType, CL_QUEUE_PROFILING_ENABLE ), gpuTimer( nullptr ), cpuTimer( nullptr )
     {
         //	Create and initialize our timer class, if the external timer shared library loaded
         if( sparseGetTimer )
@@ -44,6 +44,7 @@ public:
 
 
         clsparseEnableAsync( control, false );
+        explicit_zeroes = keep_explicit_zeroes;
     }
 
     ~xCoo2Csr( )
@@ -113,9 +114,9 @@ public:
                                                cooMatx.num_nonzeros * sizeof( cl_int ), NULL, &status );
 
         if (typeid(T) == typeid(float))
-           fileError = clsparseSCooMatrixfromFile(&cooMatx, path.c_str(), control);
+           fileError = clsparseSCooMatrixfromFile( &cooMatx, path.c_str(), control, explicit_zeroes );
         else if (typeid(T) == typeid(double))
-            fileError = clsparseDCooMatrixfromFile(&cooMatx, path.c_str(), control);
+            fileError = clsparseDCooMatrixfromFile( &cooMatx, path.c_str(), control, explicit_zeroes );
         else
             fileError = clsparseInvalidType;
 
@@ -201,6 +202,9 @@ private:
     //device values
     clsparseCsrMatrix csrMtx;
     clsparseCooMatrix cooMatx;
+
+    // host values
+    cl_bool explicit_zeroes;
 
     //matrix dimension
     int n_rows;

--- a/src/benchmarks/clsparse-bench/functions/clfunc_xCsr2Coo.hpp
+++ b/src/benchmarks/clsparse-bench/functions/clfunc_xCsr2Coo.hpp
@@ -26,7 +26,7 @@ template <typename T>
 class xCsr2Coo : public clsparseFunc
 {
 public:
-	xCsr2Coo(PFCLSPARSETIMER sparseGetTimer, size_t profileCount, cl_device_type dev_type) : clsparseFunc(dev_type, CL_QUEUE_PROFILING_ENABLE)
+	xCsr2Coo(PFCLSPARSETIMER sparseGetTimer, size_t profileCount, cl_device_type dev_type, cl_bool keep_explicit_zeroes = true) : clsparseFunc(dev_type, CL_QUEUE_PROFILING_ENABLE)
 	{
 		gpuTimer = nullptr;
 		cpuTimer = nullptr;
@@ -47,6 +47,7 @@ public:
 		}
 
 		clsparseEnableAsync(control, false);
+                explicit_zeroes = keep_explicit_zeroes;
 	}// End of constructor
 
 	~xCsr2Coo()
@@ -131,9 +132,9 @@ public:
 		CLSPARSE_V(status, "::clCreateBuffer csrMtx.rowOffsets");
 
 		if (typeid(T) == typeid(float))
-			fileError = clsparseSCsrMatrixfromFile(&csrMtx, sparseFile.c_str(), control);
+			fileError = clsparseSCsrMatrixfromFile(&csrMtx, sparseFile.c_str(), control, explicit_zeroes);
 		else if (typeid(T) == typeid(double))
-			fileError = clsparseDCsrMatrixfromFile(&csrMtx, sparseFile.c_str(), control);
+			fileError = clsparseDCsrMatrixfromFile(&csrMtx, sparseFile.c_str(), control, explicit_zeroes);
 		else
 			fileError = clsparseInvalidType;
 
@@ -262,6 +263,8 @@ private:
 	clsparseCsrMatrix csrMtx;
 	clsparseCooMatrix cooMtx;
 
+        // host values
+        cl_bool explicit_zeroes;
 
 	//OpenCL state
 	cl_command_queue_properties cqProp;

--- a/src/benchmarks/clsparse-bench/functions/clfunc_xCsr2Dense.hpp
+++ b/src/benchmarks/clsparse-bench/functions/clfunc_xCsr2Dense.hpp
@@ -26,7 +26,7 @@ template <typename T>
 class xCsr2Dense : public clsparseFunc
 {
 public:
-    xCsr2Dense(PFCLSPARSETIMER sparseGetTimer, size_t profileCount, cl_device_type dev_type) : clsparseFunc(dev_type, CL_QUEUE_PROFILING_ENABLE)
+    xCsr2Dense(PFCLSPARSETIMER sparseGetTimer, size_t profileCount, cl_device_type dev_type, cl_bool keep_explicit_zeroes = true) : clsparseFunc(dev_type, CL_QUEUE_PROFILING_ENABLE)
     {
         gpuTimer = nullptr;
         cpuTimer = nullptr;
@@ -47,6 +47,7 @@ public:
         }
 
         clsparseEnableAsync(control, false);
+        explicit_zeroes = keep_explicit_zeroes;
     }// End of constructor
 
     ~xCsr2Dense()
@@ -131,9 +132,9 @@ public:
         CLSPARSE_V(status, "::clCreateBuffer csrMtx.rowOffsets");
 
 		if (typeid(T) == typeid(float))
-			fileError = clsparseSCsrMatrixfromFile(&csrMtx, sparseFile.c_str(), control);
+			fileError = clsparseSCsrMatrixfromFile( &csrMtx, sparseFile.c_str(), control, explicit_zeroes );
 		else if (typeid(T) == typeid(double))
-			fileError = clsparseDCsrMatrixfromFile(&csrMtx, sparseFile.c_str(), control);
+			fileError = clsparseDCsrMatrixfromFile( &csrMtx, sparseFile.c_str(), control, explicit_zeroes );
 		else
 			fileError = clsparseInvalidType;
 
@@ -234,7 +235,7 @@ private:
     cldenseMatrix     denseMtx;
 
     //host values
-
+    cl_bool explicit_zeroes;
 
     //OpenCL state
     cl_command_queue_properties cqProp;

--- a/src/benchmarks/clsparse-bench/functions/clfunc_xDense2Csr.hpp
+++ b/src/benchmarks/clsparse-bench/functions/clfunc_xDense2Csr.hpp
@@ -25,7 +25,7 @@ template <typename T>
 class xDense2Csr: public clsparseFunc
 {
 public:
-    xDense2Csr( PFCLSPARSETIMER sparseGetTimer, size_t profileCount, cl_device_type devType ): clsparseFunc( devType, CL_QUEUE_PROFILING_ENABLE ), gpuTimer( nullptr ), cpuTimer( nullptr )
+    xDense2Csr( PFCLSPARSETIMER sparseGetTimer, size_t profileCount, cl_device_type devType, cl_bool keep_explicit_zeroes = true ): clsparseFunc( devType, CL_QUEUE_PROFILING_ENABLE ), gpuTimer( nullptr ), cpuTimer( nullptr )
     {
 		gpuTimer = nullptr;
 		cpuTimer = nullptr;
@@ -45,6 +45,7 @@ public:
             cpuTimerID = cpuTimer->getUniqueID( "CPU xDense2Csr", 0 );
         }
         clsparseEnableAsync( control, false );
+        explicit_zeroes = keep_explicit_zeroes;
     }// End of constructor
 
     ~xDense2Csr( )
@@ -135,9 +136,9 @@ public:
         CLSPARSE_V( status, "::clCreateBuffer csrMtx.rowOffsets" );
 
         if(typeid(T) == typeid(float))
-            fileError = clsparseSCsrMatrixfromFile( &csrMtx, sparseFile.c_str( ), control );
+            fileError = clsparseSCsrMatrixfromFile( &csrMtx, sparseFile.c_str( ), control, explicit_zeroes );
         else if (typeid(T) == typeid(double))
-            fileError = clsparseDCsrMatrixfromFile( &csrMtx, sparseFile.c_str( ), control );
+            fileError = clsparseDCsrMatrixfromFile( &csrMtx, sparseFile.c_str( ), control, explicit_zeroes );
         else
             fileError = clsparseInvalidType;
 
@@ -261,8 +262,11 @@ private:
 
     //device values
     clsparseCsrMatrix csrMtx;
-	clsparseCsrMatrix csrMatx;
+    clsparseCsrMatrix csrMatx;
     cldenseMatrix A;
+
+    // host values
+    cl_bool explicit_zeroes;
 
     //  OpenCL state
     cl_command_queue_properties cqProp;

--- a/src/benchmarks/clsparse-bench/functions/clfunc_xSpMSpM.hpp
+++ b/src/benchmarks/clsparse-bench/functions/clfunc_xSpMSpM.hpp
@@ -41,7 +41,7 @@ clsparseStatus clsparseDcsrSpGemm(const clsparseCsrMatrix* sparseMatA, const cls
 template <typename T>
 class xSpMSpM : public clsparseFunc {
 public:
-    xSpMSpM(PFCLSPARSETIMER sparseGetTimer, size_t profileCount, cl_device_type devType) : clsparseFunc(devType, CL_QUEUE_PROFILING_ENABLE), gpuTimer(nullptr), cpuTimer(nullptr)
+    xSpMSpM(PFCLSPARSETIMER sparseGetTimer, size_t profileCount, cl_device_type devType, cl_bool keep_explicit_zeroes = true) : clsparseFunc(devType, CL_QUEUE_PROFILING_ENABLE), gpuTimer(nullptr), cpuTimer(nullptr)
     {
         //	Create and initialize our timer class, if the external timer shared library loaded
         if (sparseGetTimer)
@@ -58,6 +58,7 @@ public:
             cpuTimerID = cpuTimer->getUniqueID("CPU xSpMSpM", 0);
         }
         clsparseEnableAsync(control, false);
+        explicit_zeroes = keep_explicit_zeroes;
     }
 
     ~xSpMSpM() {}
@@ -145,9 +146,9 @@ public:
 #endif
 
         if (typeid(T) == typeid(float))
-            fileError = clsparseSCsrMatrixfromFile(&csrMtx, sparseFile.c_str(), control);
+            fileError = clsparseSCsrMatrixfromFile( &csrMtx, sparseFile.c_str(), control, explicit_zeroes );
         else if (typeid(T) == typeid(double))
-            fileError = clsparseDCsrMatrixfromFile(&csrMtx, sparseFile.c_str(), control);
+            fileError = clsparseDCsrMatrixfromFile( &csrMtx, sparseFile.c_str(), control, explicit_zeroes );
         else
             fileError = clsparseInvalidType;
 
@@ -299,6 +300,7 @@ private:
     T alpha;
     T beta;
     size_t flopCnt; // Indicates total number of floating point operations
+    cl_bool explicit_zeroes;
     //  OpenCL state
     //cl_command_queue_properties cqProp;
 }; // class xSpMSpM

--- a/src/benchmarks/clsparse-bench/functions/clfunc_xSpMdV.hpp
+++ b/src/benchmarks/clsparse-bench/functions/clfunc_xSpMdV.hpp
@@ -25,7 +25,7 @@ template <typename T>
 class xSpMdV: public clsparseFunc
 {
 public:
-    xSpMdV( PFCLSPARSETIMER sparseGetTimer, size_t profileCount, cl_bool extended_precision, cl_device_type devType ): clsparseFunc( devType, CL_QUEUE_PROFILING_ENABLE ), gpuTimer( nullptr ), cpuTimer( nullptr )
+    xSpMdV( PFCLSPARSETIMER sparseGetTimer, size_t profileCount, cl_bool extended_precision, cl_device_type devType, cl_bool keep_explicit_zeroes = true ): clsparseFunc( devType, CL_QUEUE_PROFILING_ENABLE ), gpuTimer( nullptr ), cpuTimer( nullptr )
     {
         //	Create and initialize our timer class, if the external timer shared library loaded
         if( sparseGetTimer )
@@ -43,6 +43,7 @@ public:
         }
 
         clsparseEnableExtendedPrecision( control, extended_precision );
+        explicit_zeroes = keep_explicit_zeroes;
 
         clsparseEnableAsync( control, false );
     }
@@ -129,9 +130,9 @@ public:
         CLSPARSE_V( status, "::clCreateBuffer csrMtx.rowOffsets" );
 
         if(typeid(T) == typeid(float))
-            fileError = clsparseSCsrMatrixfromFile( &csrMtx, sparseFile.c_str( ), control );
+            fileError = clsparseSCsrMatrixfromFile( &csrMtx, sparseFile.c_str( ), control, explicit_zeroes );
         else if (typeid(T) == typeid(double))
-            fileError = clsparseDCsrMatrixfromFile( &csrMtx, sparseFile.c_str( ), control );
+            fileError = clsparseDCsrMatrixfromFile( &csrMtx, sparseFile.c_str( ), control, explicit_zeroes );
         else
             fileError = clsparseInvalidType;
 
@@ -252,6 +253,7 @@ private:
     // host values
     T alpha;
     T beta;
+    cl_bool explicit_zeroes;
 
     //  OpenCL state
     cl_command_queue_properties cqProp;

--- a/src/benchmarks/clsparse-bench/src/main.cpp
+++ b/src/benchmarks/clsparse-bench/src/main.cpp
@@ -130,6 +130,7 @@ int main( int argc, char *argv[ ] )
         ( "precision,r", po::value<std::string>( &precision )->default_value( "s" ), "Options: s,d,c,z" )
         ( "profile,p", po::value<size_t>( &profileCount )->default_value( 20 ), "Number of times to run the desired test function" )
         ( "extended,e", po::bool_switch()->default_value(false), "Use compensated summation to improve accuracy by emulating extended precision" )
+        ( "no_zeroes,z", po::bool_switch()->default_value(false), "Disable reading explicit zeroes from the input matrix market file.")
         ;
 
     po::variables_map vm;
@@ -164,7 +165,10 @@ int main( int argc, char *argv[ ] )
 
     cl_bool extended_precision = false;
     if (vm["extended"].as<bool>())
-                extended_precision = true;
+        extended_precision = true;
+    cl_bool explicit_zeroes = true;
+    if (vm["no_zeroes"].as<bool>())
+        explicit_zeroes = false;
 
     //	Timer module discovered and loaded successfully
     //	Initialize function pointers to call into the shared module
@@ -175,9 +179,9 @@ int main( int argc, char *argv[ ] )
     if( boost::iequals( function, "SpMdV" ) )
     {
         if( precision == "s" )
-            my_function = std::unique_ptr< clsparseFunc >( new xSpMdV< float >( sparseGetTimer, profileCount, extended_precision, CL_DEVICE_TYPE_GPU ) );
+            my_function = std::unique_ptr< clsparseFunc >( new xSpMdV< float >( sparseGetTimer, profileCount, extended_precision, CL_DEVICE_TYPE_GPU, explicit_zeroes ) );
         else if( precision == "d" )
-            my_function = std::unique_ptr< clsparseFunc >( new xSpMdV< double >( sparseGetTimer, profileCount, extended_precision, CL_DEVICE_TYPE_GPU ) );
+            my_function = std::unique_ptr< clsparseFunc >( new xSpMdV< double >( sparseGetTimer, profileCount, extended_precision, CL_DEVICE_TYPE_GPU, explicit_zeroes ) );
         else
         {
             std::cerr << "Unknown spmdv precision" << std::endl;
@@ -187,59 +191,59 @@ int main( int argc, char *argv[ ] )
     else if( boost::iequals( function, "CG" ) )
     {
         if( precision == "s" )
-            my_function = std::unique_ptr< clsparseFunc >( new xCG< float >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU ) );
+            my_function = std::unique_ptr< clsparseFunc >( new xCG< float >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU, explicit_zeroes ) );
         else
-            my_function = std::unique_ptr< clsparseFunc >( new xCG< double >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU ) );
+            my_function = std::unique_ptr< clsparseFunc >( new xCG< double >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU, explicit_zeroes ) );
     }
 
     else if( boost::iequals( function, "BiCGStab" ) )
     {
         if( precision == "s" )
-            my_function = std::unique_ptr< clsparseFunc >( new xBiCGStab< float >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU ) );
+            my_function = std::unique_ptr< clsparseFunc >( new xBiCGStab< float >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU, explicit_zeroes ) );
         else
-            my_function = std::unique_ptr< clsparseFunc >( new xBiCGStab< double >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU ) );
+            my_function = std::unique_ptr< clsparseFunc >( new xBiCGStab< double >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU, explicit_zeroes ) );
     }
     else if( boost::iequals( function, "SpMdM" ) )
     {
         if( precision == "s" )
-            my_function = std::unique_ptr< clsparseFunc >( new xSpMdM< cl_float >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU, columns ) );
+            my_function = std::unique_ptr< clsparseFunc >( new xSpMdM< cl_float >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU, columns, explicit_zeroes ) );
         else
-            my_function = std::unique_ptr< clsparseFunc >( new xSpMdM< cl_double >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU, columns ) );
+            my_function = std::unique_ptr< clsparseFunc >( new xSpMdM< cl_double >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU, columns, explicit_zeroes ) );
     }
     else if (boost::iequals(function, "SpMSpM"))
     {
         if (precision == "s")
-            my_function = std::unique_ptr< clsparseFunc>(new xSpMSpM< cl_float >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU));
+            my_function = std::unique_ptr< clsparseFunc>(new xSpMSpM< cl_float >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU, explicit_zeroes ) );
         else
-            my_function = std::unique_ptr< clsparseFunc >(new xSpMSpM< cl_double >(sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU));
+            my_function = std::unique_ptr< clsparseFunc >(new xSpMSpM< cl_double >(sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU, explicit_zeroes ) );
     }
     else if( boost::iequals( function, "Coo2Csr" ) )
     {
         if( precision == "s" )
-            my_function = std::unique_ptr< clsparseFunc >( new xCoo2Csr< float >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU ) );
+            my_function = std::unique_ptr< clsparseFunc >( new xCoo2Csr< float >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU, explicit_zeroes ) );
         else
-            my_function = std::unique_ptr< clsparseFunc >( new xCoo2Csr< double >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU ) );
+            my_function = std::unique_ptr< clsparseFunc >( new xCoo2Csr< double >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU, explicit_zeroes ) );
     }
     else if( boost::iequals( function, "Dense2Csr" ) )
     {
         if( precision == "s" )
-            my_function = std::unique_ptr< clsparseFunc >( new xDense2Csr< float >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU ) );
+            my_function = std::unique_ptr< clsparseFunc >( new xDense2Csr< float >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU, explicit_zeroes ) );
         else
-            my_function = std::unique_ptr< clsparseFunc >( new xDense2Csr< double >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU ) );
+            my_function = std::unique_ptr< clsparseFunc >( new xDense2Csr< double >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU, explicit_zeroes ) );
     }
     else if( boost::iequals( function, "Csr2Dense" ) )
     {
         if( precision == "s" )
-            my_function = std::unique_ptr< clsparseFunc >( new xCsr2Dense< cl_float >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU ) );
+            my_function = std::unique_ptr< clsparseFunc >( new xCsr2Dense< cl_float >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU, explicit_zeroes ) );
         else
-            my_function = std::unique_ptr< clsparseFunc >( new xCsr2Dense< cl_double >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU ) );
+            my_function = std::unique_ptr< clsparseFunc >( new xCsr2Dense< cl_double >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU, explicit_zeroes ) );
     }
     else if( boost::iequals( function, "Csr2Coo" ) )
     {
         if( precision == "s" )
-            my_function = std::unique_ptr< clsparseFunc >( new xCsr2Coo< cl_float >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU ) );
+            my_function = std::unique_ptr< clsparseFunc >( new xCsr2Coo< cl_float >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU, explicit_zeroes ) );
         else
-            my_function = std::unique_ptr< clsparseFunc >( new xCsr2Coo< cl_double >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU ) );
+            my_function = std::unique_ptr< clsparseFunc >( new xCsr2Coo< cl_double >( sparseGetTimer, profileCount, CL_DEVICE_TYPE_GPU, explicit_zeroes ) );
     }
     else
     {

--- a/src/benchmarks/cusparse-bench/functions/cufunc_xCoo2Csr.hpp
+++ b/src/benchmarks/cusparse-bench/functions/cufunc_xCoo2Csr.hpp
@@ -24,11 +24,12 @@ template <typename T>
 class xCoo2Csr: public cusparseFunc
 {
 public:
-    xCoo2Csr( StatisticalTimer& timer ): cusparseFunc( timer )
+    xCoo2Csr( StatisticalTimer& timer, bool read_explicit_zeroes = true ): cusparseFunc( timer )
     {
         n_rows = 0;
         n_cols = 0;
         n_vals = 0; // nnz
+        explicit_zeroes = read_explicit_zeroes;
     }
 
     ~xCoo2Csr( )
@@ -74,7 +75,7 @@ public:
             throw clsparse::io_exception( "Could not read matrix market header from disk" + path);
         }
 
-        if( cooMatrixfromFile( row_indices, col_indices, values, path.c_str( ) ) )
+        if( cooMatrixfromFile( row_indices, col_indices, values, path.c_str( ), explicit_zeroes ) )
         {
             throw clsparse::io_exception( "Could not read matrix market from disk: " + path );
         }
@@ -142,6 +143,8 @@ private:
     int  n_cols; // number of cols
     int  n_vals; // number of Non-Zero Values (nnz)
     int* colIndices;
+
+    bool explicit_zeroes;
 
     // device CUDA pointers
     int* deviceCSRRowOffsets; // Input: CSR Row Offsets

--- a/src/benchmarks/cusparse-bench/functions/cufunc_xCsr2Coo.hpp
+++ b/src/benchmarks/cusparse-bench/functions/cufunc_xCsr2Coo.hpp
@@ -24,11 +24,12 @@ template <typename T>
 class xCsr2Coo : public cusparseFunc
 {
 public:
-    xCsr2Coo(StatisticalTimer& timer): cusparseFunc(timer)
+    xCsr2Coo(StatisticalTimer& timer, bool read_explicit_zeroes = true): cusparseFunc(timer)
     {
         n_rows = 0;
         n_cols = 0;
         n_vals = 0; // nnz
+        explicit_zeroes = read_explicit_zeroes;
     }// end
 
     ~xCsr2Coo()
@@ -84,7 +85,7 @@ public:
             throw clsparse::io_exception( "Could not read matrix market header from disk: " + path);
         }
 
-        if (csrMatrixfromFile(row_offsets, col_indices, values, path.c_str()))
+        if (csrMatrixfromFile(row_offsets, col_indices, values, path.c_str(), explicit_zeroes))
         {
             throw clsparse::io_exception( "Could not read matrix market from disk: " + path);
         }
@@ -155,6 +156,8 @@ private:
     int  n_cols; // number of cols
     int  n_vals; // number of Non-Zero Values (nnz)
     int* colIndices;
+
+    bool explicit_zeroes;
 
     // device CUDA pointers
     int* deviceCSRRowOffsets; // Input: CSR Row Offsets

--- a/src/benchmarks/cusparse-bench/functions/cufunc_xCsr2dense.hpp
+++ b/src/benchmarks/cusparse-bench/functions/cufunc_xCsr2dense.hpp
@@ -24,7 +24,7 @@ template <typename T>
 class xCsr2Dense : public cusparseFunc
 {
 public:
-    xCsr2Dense( StatisticalTimer& timer ): cusparseFunc( timer )
+    xCsr2Dense( StatisticalTimer& timer, bool read_explicit_zeroes = true ): cusparseFunc( timer )
     {
         cusparseStatus_t err = cusparseCreateMatDescr( &descrA );
         CUDA_V_THROW( err, "cusparseCreateMatDescr failed" );
@@ -38,6 +38,7 @@ public:
         n_rows = 0;
         n_cols = 0;
         n_vals = 0;
+        explicit_zeroes = read_explicit_zeroes;
     }
 
     ~xCsr2Dense( )
@@ -91,7 +92,7 @@ public:
             throw clsparse::io_exception( "Could not read matrix market header from disk: " + path);
         }
 
-        if (csrMatrixfromFile(row_offsets, col_indices, values, path.c_str()))
+        if (csrMatrixfromFile(row_offsets, col_indices, values, path.c_str(), explicit_zeroes))
         {
             throw clsparse::io_exception( "Could not read matrix market from disk: " + path);
         }
@@ -173,6 +174,8 @@ private:
     int  n_rows; // number of rows
     int  n_cols; // number of cols
     int  n_vals; // number of Non-Zero Values (nnz)
+
+    bool explicit_zeroes;
 
     cusparseMatDescr_t descrA;
 

--- a/src/benchmarks/cusparse-bench/functions/cufunc_xDense2Csr.hpp
+++ b/src/benchmarks/cusparse-bench/functions/cufunc_xDense2Csr.hpp
@@ -24,7 +24,7 @@ template <typename T>
 class xDense2Csr : public cusparseFunc
 {
 public:
-    xDense2Csr(StatisticalTimer& timer) : cusparseFunc(timer)
+    xDense2Csr(StatisticalTimer& timer, bool read_explicit_zeroes) : cusparseFunc(timer)
     {
         cusparseStatus_t err = cusparseCreateMatDescr(&descrA);
         CUDA_V_THROW(err, "cusparseCreateMatDescr failed");
@@ -38,6 +38,8 @@ public:
         n_rows = 0;
         n_cols = 0;
         n_vals = 0;
+
+        explicit_zeroes = read_explicit_zeroes;
 
         device_col_indices = nullptr;
         device_row_offsets = nullptr;
@@ -92,7 +94,7 @@ public:
             throw clsparse::io_exception( "Could not read matrix market header from disk: " + path);
         }
 
-        if (csrMatrixfromFile(row_offsets, col_indices, values, path.c_str()))
+        if (csrMatrixfromFile(row_offsets, col_indices, values, path.c_str(), explicit_zeroes))
         {
             throw clsparse::io_exception( "Could not read matrix market from disk: " + path);
         }
@@ -241,6 +243,8 @@ private:
     int  n_rows; // number of rows
     int  n_cols; // number of cols
     int  n_vals; // number of Non-Zero Values (nnz)
+
+    bool explicit_zeroes;
 
     cusparseMatDescr_t descrA;
 

--- a/src/benchmarks/cusparse-bench/functions/cufunc_xSpMSpM.hpp
+++ b/src/benchmarks/cusparse-bench/functions/cufunc_xSpMSpM.hpp
@@ -25,7 +25,7 @@
 template<typename T>
 class xSpMSpM : public cusparseFunc {
 public:
-    xSpMSpM(StatisticalTimer& timer) : cusparseFunc(timer)
+    xSpMSpM(StatisticalTimer& timer, bool read_explicit_zeroes = true) : cusparseFunc(timer)
     {
         alpha = 1.0;
         beta  = 1.0;
@@ -33,6 +33,8 @@ public:
         n_rows = 0;
         n_cols = 0;
         n_vals = 0;
+
+        explicit_zeroes = read_explicit_zeroes;
 
         dev_csrValA = nullptr;
         dev_csrRowPtrA = nullptr;
@@ -117,7 +119,7 @@ public:
             throw clsparse::io_exception("Could not read matrix market header from disk");
         }
 
-        if (csrMatrixfromFile(row_offsets, col_indices, values, path.c_str()))
+        if (csrMatrixfromFile(row_offsets, col_indices, values, path.c_str(), explicit_zeroes))
         {
             throw clsparse::io_exception("Could not read matrix market header from disk");
         }
@@ -252,6 +254,8 @@ private:
     int n_rows;
     int n_cols;
     int n_vals; 
+
+    bool explicit_zeroes;
 
     csrgemm2Info_t info;
     cusparseMatDescr_t descrA;

--- a/src/benchmarks/cusparse-bench/functions/cufunc_xSpMSpM_gemm2Timed.hpp
+++ b/src/benchmarks/cusparse-bench/functions/cufunc_xSpMSpM_gemm2Timed.hpp
@@ -25,7 +25,7 @@
 template<typename T>
 class xSpMSpM : public cusparseFunc {
 public:
-    xSpMSpM(StatisticalTimer& timer) : cusparseFunc(timer)
+    xSpMSpM( StatisticalTimer& timer, bool read_explicit_zeroes = true ) : cusparseFunc(timer)
     {
         alpha = 1.0;
         beta  = 1.0;
@@ -33,6 +33,8 @@ public:
         n_rows = 0;
         n_cols = 0;
         n_vals = 0;
+
+        explicit_zeroes = read_explicit_zeroes;
 
         dev_csrValA = nullptr;
         dev_csrRowPtrA = nullptr;
@@ -123,7 +125,7 @@ public:
             throw clsparse::io_exception("Could not read matrix market header from disk");
         }
 
-        if (csrMatrixfromFile(row_offsets, col_indices, values, path.c_str()))
+        if (csrMatrixfromFile(row_offsets, col_indices, values, path.c_str(), explicit_zeroes))
         {
             throw clsparse::io_exception("Could not read matrix market header from disk");
         }
@@ -224,6 +226,8 @@ private:
     int n_rows;
     int n_cols;
     int n_vals; 
+
+    bool explicit_zeroes;
 
     csrgemm2Info_t info;
     cusparseMatDescr_t descrA;

--- a/src/benchmarks/cusparse-bench/functions/cufunc_xSpMdV.hpp
+++ b/src/benchmarks/cusparse-bench/functions/cufunc_xSpMdV.hpp
@@ -25,7 +25,7 @@ template <typename T>
 class xSpMdV : public cusparseFunc
 {
 public:
-    xSpMdV( StatisticalTimer& timer ): cusparseFunc( timer ), transA( CUSPARSE_OPERATION_NON_TRANSPOSE )
+    xSpMdV( StatisticalTimer& timer, bool read_explicit_zeroes = true ): cusparseFunc( timer ), transA( CUSPARSE_OPERATION_NON_TRANSPOSE )
     {
         cusparseStatus_t err = cusparseCreateMatDescr( &descrA );
         CUDA_V_THROW( err, "cusparseCreateMatDescr failed" );
@@ -35,6 +35,8 @@ public:
 
         err = cusparseSetMatIndexBase( descrA, CUSPARSE_INDEX_BASE_ZERO );
         CUDA_V_THROW( err, "cusparseSetMatIndexBase failed" );
+
+        explicit_zeroes = read_explicit_zeroes;
     }
 
     ~xSpMdV( )
@@ -84,7 +86,7 @@ public:
             throw clsparse::io_exception( "Could not read matrix market header from disk: " + path);
         }
 
-        if (csrMatrixfromFile( row_offsets, col_indices, values, path.c_str( ) ) )
+        if (csrMatrixfromFile( row_offsets, col_indices, values, path.c_str( ), explicit_zeroes ) )
         {
             throw clsparse::io_exception( "Could not read matrix market from disk: " + path);
         }
@@ -173,6 +175,8 @@ private:
     int n_rows;
     int n_cols;
     int n_vals;
+
+    bool explicit_zeroes;
 
     T alpha;
     T beta;

--- a/src/benchmarks/cusparse-bench/include/mm_reader.hpp
+++ b/src/benchmarks/cusparse-bench/include/mm_reader.hpp
@@ -24,10 +24,10 @@ int sparseHeaderfromFile( int* nnz, int* rows, int* cols, const char* filePath )
 
 template< class T > int
 cooMatrixfromFile( std::vector< int >& row_indices, std::vector< int >& col_indices,
-std::vector< T >& values, const char* filePath );
+std::vector< T >& values, const char* filePath, bool read_explicit_zeroes = true );
 
 template< class T > int
 csrMatrixfromFile( std::vector< int >& row_offsets, std::vector< int >& col_indices,
-std::vector< T >& values, const char* filePath );
+std::vector< T >& values, const char* filePath, bool read_explicit_zeroes = true );
 
 #endif

--- a/src/benchmarks/cusparse-bench/src/main.cpp
+++ b/src/benchmarks/cusparse-bench/src/main.cpp
@@ -129,6 +129,7 @@ int main(int argc, char *argv[])
                 "SpMdV, SpMSpM, Csr2Dense, Dense2Csr, Csr2Coo, Coo2Csr" )
     ( "precision,r", po::value<std::string>( &precision )->default_value( "s" ), "Options: s,d,c,z" )
     ( "profile,p", po::value<int>( &profileCount )->default_value( 20 ), "Time and report the kernel speed (default: profiling off)" )
+    ( "no_zeroes,z", po::bool_switch()->default_value(false), "Disable reading explicit zeroes from the input matrix market file.")
     ;
 
   po::variables_map vm;
@@ -154,6 +155,10 @@ int main(int argc, char *argv[])
       return false;
   }
 
+  cl_bool explicit_zeroes = true;
+  if (vm["no_zeroes"].as<bool>())
+    explicit_zeroes = false;
+
   StatisticalTimer& timer = StatisticalTimer::getInstance( );
   timer.Reserve( 3, profileCount );
   timer.setNormalize( true );
@@ -162,10 +167,10 @@ int main(int argc, char *argv[])
   if( boost::iequals( function, "SpMdV" ) )
   {
     if( precision == "s" )
-        my_function = std::unique_ptr< cusparseFunc >( new xSpMdV< float >( timer ) );
+        my_function = std::unique_ptr< cusparseFunc >( new xSpMdV< float >( timer, explicit_zeroes ) );
     else if( precision == "d" )
     //    my_function = std::make_unique< xSpMdV< double > >( timer );
-      my_function = std::unique_ptr< cusparseFunc >( new xSpMdV< double >( timer ) );
+      my_function = std::unique_ptr< cusparseFunc >( new xSpMdV< double >( timer, explicit_zeroes ) );
     else
     {
       std::cerr << "Unknown spmdv precision" << std::endl;
@@ -175,9 +180,9 @@ int main(int argc, char *argv[])
   else if (boost::iequals(function, "SpMSpM"))
   {
       if (precision == "s")
-          my_function = std::unique_ptr< cusparseFunc >(new xSpMSpM< float >(timer));
+          my_function = std::unique_ptr< cusparseFunc >(new xSpMSpM< float >( timer, explicit_zeroes ));
       else if (precision == "d") // Currently not supported
-          my_function = std::unique_ptr< cusparseFunc >(new xSpMSpM< double >(timer));
+          my_function = std::unique_ptr< cusparseFunc >(new xSpMSpM< double >( timer, explicit_zeroes ));
       else
       {
           std::cerr << "Unknown spmspm precison" << std::endl;
@@ -187,9 +192,9 @@ int main(int argc, char *argv[])
   else if( boost::iequals( function, "Csr2Dense" ) )
   {
       if( precision == "s" )
-          my_function = std::unique_ptr< cusparseFunc >( new xCsr2Dense< float >( timer ) );
+          my_function = std::unique_ptr< cusparseFunc >( new xCsr2Dense< float >( timer, explicit_zeroes ) );
       else if( precision == "d" )
-          my_function = std::unique_ptr< cusparseFunc >( new xCsr2Dense< double >( timer ) );
+          my_function = std::unique_ptr< cusparseFunc >( new xCsr2Dense< double >( timer, explicit_zeroes ) );
       else
       {
           std::cerr << "Unknown xCsr2Dense precision" << std::endl;
@@ -200,11 +205,11 @@ int main(int argc, char *argv[])
   {
       if (precision == "s")
       {
-          my_function = std::unique_ptr< cusparseFunc >(new xCsr2Coo< float >(timer));
+          my_function = std::unique_ptr< cusparseFunc >(new xCsr2Coo< float >( timer, explicit_zeroes ));
       }
       else if (precision == "d")
       {
-          my_function = std::unique_ptr< cusparseFunc >(new xCsr2Coo< double >(timer));
+          my_function = std::unique_ptr< cusparseFunc >(new xCsr2Coo< double >( timer, explicit_zeroes ));
       }
       else
       {
@@ -216,11 +221,11 @@ int main(int argc, char *argv[])
   {
       if (precision == "s")
       {
-          my_function = std::unique_ptr< cusparseFunc >(new xDense2Csr< float >(timer));
+          my_function = std::unique_ptr< cusparseFunc >(new xDense2Csr< float >( timer, explicit_zeroes ));
       }
       else if (precision == "d")
       {
-          my_function = std::unique_ptr< cusparseFunc >(new xDense2Csr< double >(timer));
+          my_function = std::unique_ptr< cusparseFunc >(new xDense2Csr< double >( timer, explicit_zeroes ));
       }
       else
       {
@@ -232,11 +237,11 @@ int main(int argc, char *argv[])
   {
       if( precision == "s" )
       {
-          my_function = std::unique_ptr< cusparseFunc >( new xCoo2Csr< float >( timer ) );
+          my_function = std::unique_ptr< cusparseFunc >( new xCoo2Csr< float >( timer, explicit_zeroes ) );
       }
       else
       {
-          my_function = std::unique_ptr< cusparseFunc >( new xCoo2Csr< double >( timer ) );
+          my_function = std::unique_ptr< cusparseFunc >( new xCoo2Csr< double >( timer, explicit_zeroes ) );
       }
   }
   else

--- a/src/include/clSPARSE.h
+++ b/src/include/clSPARSE.h
@@ -507,17 +507,21 @@ extern "C" {
     * \param[out] cooMatx  The COO sparse structure that represents the matrix in device memory
     * \param[in] filePath  A path in the file-system to the sparse matrix file
     * \param[in] control A valid clsparseControl created with clsparseCreateControl
+    * \param[in] read_explicit_zeroes If the file contains values explicitly declared zero, this controls
+    * whether they are stored in the COO
     *
-    * \note The number of non-zeroes actually read from the file may be less than the number of
-    * non-zeroes reported from the file header
+    * \note The number of non-zeroes actually read from the file may be different than the number of
+    * non-zeroes reported from the file header. Symmetrix matrices may store up to twice as many non-zero
+    * values compared to the number of values in the file. Explicitly declared zeroes may be stored
+    * or not depending on the input \p read_explicit_zeroes.
     * \note The OpenCL device memory must be allocated before the call to this function.
-    * \post The sparse data is sorted first by row, then by column
+    * \post The sparse data is sorted first by row, then by column.
     * \returns \b clsparseSuccess
     *
     * \ingroup FILE
     */
     CLSPARSE_EXPORT clsparseStatus
-        clsparseSCooMatrixfromFile( clsparseCooMatrix* cooMatx, const char* filePath, clsparseControl control );
+        clsparseSCooMatrixfromFile( clsparseCooMatrix* cooMatx, const char* filePath, clsparseControl control, cl_bool read_explicit_zeroes );
 
     /*!
      * \brief Read sparse matrix data from file in double precision COO format
@@ -529,17 +533,21 @@ extern "C" {
      * \param[out] cooMatx  The COO sparse structure that represents the matrix in device memory
      * \param[in] filePath  A path in the file-system to the sparse matrix file
      * \param[in] control A valid clsparseControl created with clsparseCreateControl
+     * \param[in] read_explicit_zeroes If the file contains values explicitly declared zero, this controls
+     * whether they are stored in the COO
      *
      * \note The number of non-zeroes actually read from the file may be less than the number of
-     * non-zeroes reported from the file header
+     * non-zeroes reported from the file header. Symmetrix matrices may store up to twice as many non-zero
+     * values compared to the number of values in the file. Explicitly declared zeroes may be stored
+     * or not depending on the input \p read_explicit_zeroes.
      * \note The OpenCL device memory must be allocated before the call to this function.
-     * \post The sparse data is sorted first by row, then by column
+     * \post The sparse data is sorted first by row, then by column.
      * \returns \b clsparseSuccess
      *
      * \ingroup FILE
      */
     CLSPARSE_EXPORT clsparseStatus
-        clsparseDCooMatrixfromFile( clsparseCooMatrix* cooMatx, const char* filePath, clsparseControl control );
+        clsparseDCooMatrixfromFile( clsparseCooMatrix* cooMatx, const char* filePath, clsparseControl control, cl_bool read_explicit_zeroes );
 
     /*!
      * \brief Read sparse matrix data from file in single precision CSR format
@@ -550,17 +558,21 @@ extern "C" {
      * \param[out] csrMatx  The CSR sparse structure that represents the matrix in device memory
      * \param[in] filePath  A path in the file-system to the sparse matrix file
      * \param[in] control A valid clsparseControl created with clsparseCreateControl
+     * \param[in] read_explicit_zeroes If the file contains values explicitly declared zero, this controls
+     * whether they are stored in the CSR
      *
      * \note The number of non-zeroes actually read from the file may be less than the number of
-     * non-zeroes reported from the file header
+     * non-zeroes reported from the file header. Symmetrix matrices may store up to twice as many non-zero
+     * values compared to the number of values in the file. Explicitly declared zeroes may be stored
+     * or not depending on the input \p read_explicit_zeroes.
      * \note The OpenCL device memory must be allocated before the call to this function.
-     * \post The sparse data is sorted first by row, then by column
+     * \post The sparse data is sorted first by row, then by column.
      * \returns \b clsparseSuccess
      *
      * \ingroup FILE
      */
     CLSPARSE_EXPORT clsparseStatus
-        clsparseSCsrMatrixfromFile( clsparseCsrMatrix* csrMatx, const char* filePath, clsparseControl control );
+        clsparseSCsrMatrixfromFile( clsparseCsrMatrix* csrMatx, const char* filePath, clsparseControl control, cl_bool read_explicit_zeroes );
 
     /*!
      * \brief Read sparse matrix data from file in double precision CSR format
@@ -572,9 +584,13 @@ extern "C" {
      * \param[out] csrMatx  The CSR sparse structure that represents the matrix in device memory
      * \param[in] filePath  A path in the file-system to the sparse matrix file
      * \param[in] control A valid clsparseControl created with clsparseCreateControl
+     * \param[in] read_explicit_zeroes If the file contains values explicitly declared zero, this controls
+     * whether they are stored in the CSR
      *
      * \note The number of non-zeroes actually read from the file may be less than the number of
-     * non-zeroes reported from the file header
+     * non-zeroes reported from the file header. Symmetrix matrices may store up to twice as many non-zero
+     * values compared to the number of values in the file. Explicitly declared zeroes may be stored
+     * or not depending on the input \p read_explicit_zeroes.
      * \note The OpenCL device memory must be allocated before the call to this function.
      * \post The sparse data is sorted first by row, then by column
      * \returns \b clsparseSuccess
@@ -582,7 +598,7 @@ extern "C" {
      * \ingroup FILE
      */
     CLSPARSE_EXPORT clsparseStatus
-        clsparseDCsrMatrixfromFile( clsparseCsrMatrix* csrMatx, const char* filePath, clsparseControl control );
+        clsparseDCsrMatrixfromFile( clsparseCsrMatrix* csrMatx, const char* filePath, clsparseControl control, cl_bool read_explicit_zeroes );
 
     /*!
      * \brief Calculate the amount of device memory required to hold meta-data for csr-adaptive SpM-dV algorithm

--- a/src/library/io/mm-reader.cpp
+++ b/src/library/io/mm-reader.cpp
@@ -87,10 +87,10 @@ public:
 
     bool MMReadHeader( FILE* infile );
     bool MMReadHeader( const std::string& filename );
-    bool MMReadFormat( const std::string& _filename );
+    bool MMReadFormat( const std::string& _filename, cl_bool read_explicit_zeroes );
     int MMReadBanner( FILE* infile );
     int MMReadMtxCrdSize( FILE* infile );
-    void MMGenerateCOOFromFile( FILE* infile );
+    void MMGenerateCOOFromFile( FILE* infile, cl_bool read_explicit_zeroes );
 
     int GetNumRows( )
     {
@@ -192,7 +192,7 @@ bool MatrixMarketReader<FloatType>::MMReadHeader( const std::string &filename )
 }
 
 template<typename FloatType>
-bool MatrixMarketReader<FloatType>::MMReadFormat( const std::string &filename )
+bool MatrixMarketReader<FloatType>::MMReadFormat( const std::string &filename, cl_bool read_explicit_zeroes )
 {
     FILE *mm_file = ::fopen( filename.c_str( ), "r" );
     if( mm_file == NULL )
@@ -212,7 +212,7 @@ bool MatrixMarketReader<FloatType>::MMReadFormat( const std::string &filename )
     else
         unsym_coords = new Coordinate<FloatType>[ nNZ ];
 
-    MMGenerateCOOFromFile( mm_file );
+    MMGenerateCOOFromFile( mm_file, read_explicit_zeroes );
     ::fclose( mm_file );
 
     return 0;
@@ -249,13 +249,13 @@ void FillCoordData( char Typecode[ ],
 }
 
 template<typename FloatType>
-void MatrixMarketReader<FloatType>::MMGenerateCOOFromFile( FILE *infile )
+void MatrixMarketReader<FloatType>::MMGenerateCOOFromFile( FILE *infile, cl_bool read_explicit_zeroes )
 {
     int unsym_actual_nnz = 0;
     FloatType val;
     int ir, ic;
 
-    const int exp_zeroes = 0;
+    const int exp_zeroes = read_explicit_zeroes;
 
     //silence warnings from fscanf (-Wunused-result)
     int rv = 0;
@@ -446,7 +446,7 @@ clsparseHeaderfromFile( cl_int* nnz, cl_int* row, cl_int* col, const char* fileP
 // Pre-condition: This function assumes that the device memory buffers have been
 // pre-allocated by the caller
 clsparseStatus
-clsparseSCooMatrixfromFile( clsparseCooMatrix* cooMatx, const char* filePath, clsparseControl control )
+clsparseSCooMatrixfromFile( clsparseCooMatrix* cooMatx, const char* filePath, clsparseControl control, cl_bool read_explicit_zeroes )
 {
     clsparseCooMatrixPrivate* pCooMatx = static_cast<clsparseCooMatrixPrivate*>( cooMatx );
 
@@ -464,7 +464,7 @@ clsparseSCooMatrixfromFile( clsparseCooMatrix* cooMatx, const char* filePath, cl
         return clsparseInvalidFileFormat;
 
     MatrixMarketReader< cl_float > mm_reader;
-    if( mm_reader.MMReadFormat( filePath ) )
+    if( mm_reader.MMReadFormat( filePath, read_explicit_zeroes ) )
         return clsparseInvalidFile;
 
     pCooMatx->num_rows = mm_reader.GetNumRows( );
@@ -496,7 +496,7 @@ clsparseSCooMatrixfromFile( clsparseCooMatrix* cooMatx, const char* filePath, cl
 }
 
 clsparseStatus
-clsparseDCooMatrixfromFile( clsparseCooMatrix* cooMatx, const char* filePath, clsparseControl control )
+clsparseDCooMatrixfromFile( clsparseCooMatrix* cooMatx, const char* filePath, clsparseControl control, cl_bool read_explicit_zeroes )
 {
     clsparseCooMatrixPrivate* pCooMatx = static_cast<clsparseCooMatrixPrivate*>( cooMatx );
 
@@ -514,7 +514,7 @@ clsparseDCooMatrixfromFile( clsparseCooMatrix* cooMatx, const char* filePath, cl
         return clsparseInvalidFileFormat;
 
     MatrixMarketReader< cl_double > mm_reader;
-    if( mm_reader.MMReadFormat( filePath ) )
+    if( mm_reader.MMReadFormat( filePath, read_explicit_zeroes ) )
         return clsparseInvalidFile;
 
     pCooMatx->num_rows = mm_reader.GetNumRows( );
@@ -546,7 +546,7 @@ clsparseDCooMatrixfromFile( clsparseCooMatrix* cooMatx, const char* filePath, cl
 }
 
 clsparseStatus
-clsparseSCsrMatrixfromFile(clsparseCsrMatrix* csrMatx, const char* filePath, clsparseControl control)
+clsparseSCsrMatrixfromFile(clsparseCsrMatrix* csrMatx, const char* filePath, clsparseControl control, cl_bool read_explicit_zeroes )
 {
     clsparseCsrMatrixPrivate* pCsrMatx = static_cast<clsparseCsrMatrixPrivate*>( csrMatx );
 
@@ -566,7 +566,7 @@ clsparseSCsrMatrixfromFile(clsparseCsrMatrix* csrMatx, const char* filePath, cls
     // Read data from a file on disk into CPU buffers
     // Data is read natively as COO format with the reader
     MatrixMarketReader< cl_float > mm_reader;
-    if( mm_reader.MMReadFormat( filePath ) )
+    if( mm_reader.MMReadFormat( filePath, read_explicit_zeroes ) )
         return clsparseInvalidFile;
     // BUG: We need to check to see if openCL buffers currently exist and deallocate them first!
     // FIX: Below code will check whether the buffers were allocated in the first place;
@@ -629,7 +629,7 @@ clsparseSCsrMatrixfromFile(clsparseCsrMatrix* csrMatx, const char* filePath, cls
 }
 
 clsparseStatus
-clsparseDCsrMatrixfromFile(clsparseCsrMatrix* csrMatx, const char* filePath, clsparseControl control)
+clsparseDCsrMatrixfromFile( clsparseCsrMatrix* csrMatx, const char* filePath, clsparseControl control, cl_bool read_explicit_zeroes )
 {
     clsparseCsrMatrixPrivate* pCsrMatx = static_cast<clsparseCsrMatrixPrivate*>( csrMatx );
 
@@ -649,7 +649,7 @@ clsparseDCsrMatrixfromFile(clsparseCsrMatrix* csrMatx, const char* filePath, cls
     // Read data from a file on disk into CPU buffers
     // Data is read natively as COO format with the reader
     MatrixMarketReader< cl_double > mm_reader;
-    if( mm_reader.MMReadFormat( filePath ) )
+    if( mm_reader.MMReadFormat( filePath, read_explicit_zeroes ) )
         return clsparseInvalidFile;
 
     // BUG: We need to check to see if openCL buffers currently exist and deallocate them first!
@@ -735,7 +735,7 @@ clsparseDCsrMatrixfromFile(clsparseCsrMatrix* csrMatx, const char* filePath, cls
 }
 
 //clsparseStatus
-//clsparseCsrMatrixfromFile( clsparseCsrMatrix* csrMatx, const char* filePath, clsparseControl control )
+//clsparseCsrMatrixfromFile( clsparseCsrMatrix* csrMatx, const char* filePath, clsparseControl control, cl_bool read_explicit_zeroes )
 //{
 //    clsparseCsrMatrixPrivate* pCsrMatx = static_cast<clsparseCsrMatrixPrivate*>( csrMatx );
 
@@ -755,7 +755,7 @@ clsparseDCsrMatrixfromFile(clsparseCsrMatrix* csrMatx, const char* filePath, cls
 //    // Read data from a file on disk into CPU buffers
 //    // Data is read natively as COO format with the reader
 //    MatrixMarketReader< cl_float > mm_reader;
-//    if( mm_reader.MMReadFormat( filePath ) )
+//    if( mm_reader.MMReadFormat( filePath, read_explicit_zeroes ) )
 //        return clsparseInvalidFile;
 
 //    // BUG: We need to check to see if openCL buffers currently exist and deallocate them first!

--- a/src/tests/resources/csr_matrix_environment.h
+++ b/src/tests/resources/csr_matrix_environment.h
@@ -45,7 +45,8 @@ public:
     explicit CSREnvironment( const std::string& path,
                              cl_double alpha, cl_double beta,
                              cl_command_queue queue,
-                             cl_context context ):
+                             cl_context context,
+                             cl_bool read_explicit_zeroes = true ):
                              queue( queue ),
                              context( context )
     {
@@ -72,7 +73,7 @@ public:
         csrDMatrix.rowOffsets = ::clCreateBuffer( context, CL_MEM_READ_ONLY,
                                                   ( csrDMatrix.num_rows + 1 ) * sizeof( cl_int ), NULL, &status );
 
-        clsparseStatus fileError = clsparseDCsrMatrixfromFile( &csrDMatrix, file_name.c_str( ), CLSE::control );
+        clsparseStatus fileError = clsparseDCsrMatrixfromFile( &csrDMatrix, file_name.c_str( ), CLSE::control, read_explicit_zeroes );
         if( fileError != clsparseSuccess )
             throw std::runtime_error( "Could not read matrix market data from disk: " + file_name );
 

--- a/src/tests/resources/sparse_matrix_environment.h
+++ b/src/tests/resources/sparse_matrix_environment.h
@@ -43,7 +43,7 @@ public:
     using sMatrixType = uBLAS::compressed_matrix<float,  uBLAS::row_major, 0, uBLAS::unbounded_array<int> >;
     //using dMatrixType = uBLAS::compressed_matrix<double, uBLAS::row_major, 0, uBLAS::unbounded_array<size_t> >;
 
-    explicit CSRSparseEnvironment(const std::string& path, cl_command_queue queue, cl_context context)
+    explicit CSRSparseEnvironment(const std::string& path, cl_command_queue queue, cl_context context, cl_bool explicit_zeroes = true)
         : queue(queue), context(context)
     {
         file_name = path;
@@ -69,7 +69,7 @@ public:
         csrSMatrix.rowOffsets = ::clCreateBuffer(context, CL_MEM_READ_ONLY,
             (csrSMatrix.num_rows + 1) * sizeof(cl_int), NULL, &status);
 
-        clsparseStatus fileError = clsparseSCsrMatrixfromFile(&csrSMatrix, file_name.c_str(), CLSE::control);
+        clsparseStatus fileError = clsparseSCsrMatrixfromFile(&csrSMatrix, file_name.c_str(), CLSE::control, explicit_zeroes);
         if (fileError != clsparseSuccess)
             throw std::runtime_error("Could not read matrix market data from disk");
 

--- a/src/tests/test-blas3.cpp
+++ b/src/tests/test-blas3.cpp
@@ -48,6 +48,7 @@ clsparseControl ClSparseEnvironment::control = NULL;
 cl_command_queue ClSparseEnvironment::queue = NULL;
 cl_context ClSparseEnvironment::context = NULL;
 
+static cl_bool explicit_zeroes = true;
 
 namespace po = boost::program_options;
 namespace uBLAS = boost::numeric::ublas;
@@ -666,7 +667,9 @@ int main (int argc, char* argv[])
             ("cols,c", po::value(&B_num_cols)->default_value(8),
              "Number of columns in B matrix while calculating sp_A * d_B = d_C")
             ("vals,v", po::value(&B_values)->default_value(1.0),
-             "Initial value of B columns");
+             "Initial value of B columns")
+            ("no_zeroes,z", po::bool_switch()->default_value(false),
+             "Disable reading explicit zeroes from the input matrix market file.");
 
 
     //	Parse the command line options, ignore unrecognized options and collect them into a vector of strings
@@ -709,6 +712,9 @@ int main (int argc, char* argv[])
         }
     }
 
+    if (vm["no_zeroes"].as<bool>())
+        explicit_zeroes = false;
+
     if (boost::iequals(function, "SpMdM"))
     {
         std::cout << "SpMdM Testing \n";
@@ -719,7 +725,7 @@ int main (int argc, char* argv[])
         //order does matter!
         ::testing::AddGlobalTestEnvironment(new CLSE(pID, dID));
         ::testing::AddGlobalTestEnvironment(new CSRE(path, alpha, beta,
-            CLSE::queue, CLSE::context));
+            CLSE::queue, CLSE::context, explicit_zeroes));
 
     }
     else if (boost::iequals(function, "SpMSpM"))
@@ -731,7 +737,7 @@ int main (int argc, char* argv[])
         ::testing::InitGoogleTest(&argc, argv);
 
         ::testing::AddGlobalTestEnvironment(new CLSE(pID, dID));
-        ::testing::AddGlobalTestEnvironment(new SPER(path, CLSE::queue, CLSE::context));
+        ::testing::AddGlobalTestEnvironment(new SPER(path, CLSE::queue, CLSE::context, explicit_zeroes));
     }
     else if (boost::iequals(function, "All"))
     {
@@ -739,8 +745,8 @@ int main (int argc, char* argv[])
         //order does matter!
         ::testing::AddGlobalTestEnvironment(new CLSE(pID, dID));
         ::testing::AddGlobalTestEnvironment(new CSRE(path, alpha, beta,
-            CLSE::queue, CLSE::context));
-        ::testing::AddGlobalTestEnvironment(new SPER(path, CLSE::queue, CLSE::context));
+            CLSE::queue, CLSE::context, explicit_zeroes));
+        ::testing::AddGlobalTestEnvironment(new SPER(path, CLSE::queue, CLSE::context, explicit_zeroes));
     }
     else
     {

--- a/src/tests/test-conversion.cpp
+++ b/src/tests/test-conversion.cpp
@@ -42,6 +42,8 @@ clsparseControl ClSparseEnvironment::control = NULL;
 cl_command_queue ClSparseEnvironment::queue = NULL;
 cl_context ClSparseEnvironment::context = NULL;
 
+static cl_bool explicit_zeroes = true;
+
 namespace po = boost::program_options;
 namespace uBLAS = boost::numeric::ublas;
 
@@ -344,7 +346,8 @@ public:
 
             status = clsparseSCooMatrixfromFile(&cooMatrix,
                                                 CSRE::file_name.c_str(),
-                                                CLSE::control);
+                                                CLSE::control,
+                                                explicit_zeroes);
             ASSERT_EQ(clsparseSuccess, status);
 
             // To save memory let us use the CSRE gpu matrix which have the
@@ -398,7 +401,8 @@ public:
 
             status = clsparseDCooMatrixfromFile(&cooMatrix,
                                                 CSRE::file_name.c_str(),
-                                                CLSE::control);
+                                                CLSE::control,
+                                                explicit_zeroes);
             ASSERT_EQ(clsparseSuccess, status);
 
             // To save memory let us use the CSRE gpu matrix which have the
@@ -689,7 +693,9 @@ int main (int argc, char* argv[])
             ("platform,l", po::value(&platform)->default_value("AMD"),
              "OpenCL platform: AMD or NVIDIA.")
             ("device,d", po::value(&dID)->default_value(0),
-             "Device id within platform.");
+             "Device id within platform.")
+            ("no_zeroes,z", po::bool_switch()->default_value(false),
+             "Disable reading explicit zeroes from the input matrix market file.");
 
     //	Parse the command line options, ignore unrecognized options and collect them into a vector of strings
     //  Googletest itself accepts command line flags that we wish to pass further on
@@ -733,10 +739,13 @@ int main (int argc, char* argv[])
 
     }
 
+    if (vm["no_zeroes"].as<bool>())
+        explicit_zeroes = false;
+
     ::testing::InitGoogleTest(&argc, argv);
     //order does matter!
     ::testing::AddGlobalTestEnvironment( new CLSE(pID, dID));
     ::testing::AddGlobalTestEnvironment( new CSRE(path, 1, 0,
-                                                  CLSE::queue, CLSE::context));
+                                                  CLSE::queue, CLSE::context, explicit_zeroes ));
     return RUN_ALL_TESTS();
 }

--- a/src/tests/test-solvers.cpp
+++ b/src/tests/test-solvers.cpp
@@ -43,6 +43,7 @@ cl_command_queue ClSparseEnvironment::queue = NULL;
 cl_context ClSparseEnvironment::context = NULL;
 //cl_uint ClSparseEnvironment::N = 1024;
 
+static cl_bool explicit_zeroes = true;
 
 namespace po = boost::program_options;
 namespace uBLAS = boost::numeric::ublas;
@@ -276,7 +277,9 @@ int main (int argc, char* argv[])
             ("initx,x", po::value(&initialUnknownsValue)->default_value(0),
              "Initial value for vector of unknowns")
             ("initb,b", po::value(&initialRhsValue)->default_value(1),
-             "Initial value for rhs vector");
+             "Initial value for rhs vector")
+            ("no_zeroes,z", po::bool_switch()->default_value(false),
+             "Disable reading explicit zeroes from the input matrix market file.");
 
 
     po::variables_map vm;
@@ -321,6 +324,9 @@ int main (int argc, char* argv[])
 
     }
 
+    if (vm["no_zeroes"].as<bool>())
+        explicit_zeroes = false;
+
     //pickup preconditioner
     if ( boost::iequals(strPrecond, "Diagonal"))
     {
@@ -363,7 +369,7 @@ int main (int argc, char* argv[])
     //order does matter!
     ::testing::AddGlobalTestEnvironment( new CLSE(pID, dID));
     ::testing::AddGlobalTestEnvironment( new CSRE(path, 0, 0,
-                                                  CLSE::queue, CLSE::context));
+                                                  CLSE::queue, CLSE::context, explicit_zeroes));
 
     return RUN_ALL_TESTS();
 

--- a/src/tests/test_readMMcoo.cpp
+++ b/src/tests/test_readMMcoo.cpp
@@ -28,6 +28,8 @@ clsparseControl ClSparseEnvironment::control = NULL;
 cl_command_queue ClSparseEnvironment::queue = NULL;
 cl_context ClSparseEnvironment::context = NULL;
 
+static cl_bool explicit_zeroes = true;
+
 /** Just a simple test checking if the io functions for matrices are ok */
 
 namespace po = boost::program_options;
@@ -70,7 +72,7 @@ TEST( MM_file, load )
                                            cooMatx.num_nonzeros * sizeof( cl_int ), NULL, &status );
     cooMatx.rowIndices = ::clCreateBuffer( CLSE::context, CL_MEM_READ_ONLY,
                                            cooMatx.num_nonzeros * sizeof( cl_int ), NULL, &status );
-    clsparseCooMatrixfromFile( &cooMatx, path.c_str( ), CLSE::control );
+    clsparseCooMatrixfromFile( &cooMatx, path.c_str( ), CLSE::control, explicit_zeroes );
 
     clsparseCsrMatrix csrMatx;
     clsparseInitCsrMatrix( &csrMatx );
@@ -150,7 +152,9 @@ int main( int argc, char* argv[ ] )
     desc.add_options( )
         ( "help,h", "Produce this message." )
         ( "path,p", po::value( &path )->required( ),
-        "Path to matrix in mtx format." );
+        "Path to matrix in mtx format." )
+        ("no_zeroes,z", po::bool_switch()->default_value(false),
+         "Disable reading explicit zeroes from the input matrix market file.");
 
     po::variables_map vm;
     try
@@ -164,6 +168,9 @@ int main( int argc, char* argv[ ] )
         std::cerr << desc << std::endl;
         return false;
     }
+
+    if (vm["no_zeroes"].as<bool>())
+        explicit_zeroes = false;
 
     double alpha = 1.0;
     double beta = 1.0;


### PR DESCRIPTION
Fixes issue #146 

As requested in the previous patch (#163), I've made changes to the matrix market reader functions (e.g. clsparseSCsrMatrixfromFile) to take an added boolean input. This input controls whether the function reads explicit zeroes that are stored in the matrix market file, or whether it ignores them and does not put them in the data structure.

Changed all the programs that eventually call the matrix market reader to (by default) read in explicit zeroes, as requested in [this post](https://github.com/clMathLibraries/clSPARSE/issues/144#issuecomment-139586338) by @kknox. Added command line parameters to all of the applications (except the samples) to control this.

@kvaragan, I was unable to reproduce the error you brought up in [this post](https://github.com/clMathLibraries/clSPARSE/pull/163#issuecomment-148665224) from the previous PR. I fixed some other errors in the test programs along the way, and I believe the test-conversion application only fails in the same places it failed before (e.g. Issue #153).