### PR TITLE
Fix compile error on some platforms by explicitly including stdexcept for statistical timer headers

### DIFF
--- a/src/benchmarks/clsparse-bench/include/statisticalTimer.h
+++ b/src/benchmarks/clsparse-bench/include/statisticalTimer.h
@@ -20,6 +20,7 @@
 #include <iosfwd>
 #include <vector>
 #include <algorithm>
+#include <stdexcept>
 
 /**
  * \file clAmdFft.StatisticalTimer.h

--- a/src/include/clsparseTimer.hpp
+++ b/src/include/clsparseTimer.hpp
@@ -29,6 +29,7 @@
 #include <vector>
 #include <functional>
 #include <string>
+#include <stdexcept>
 
 #if defined(__APPLE__) || defined(__MACOSX)
 #   include <OpenCL/cl.h>


### PR DESCRIPTION
On some platforms, clSPARSE complains that runtime_error is not a member of std. This commit fixes this by explicitly including the `<stdexcept>` header in the relevant areas.
