### PR TITLE
Fixed some buffer overruns in CSR-Adaptive kernels.

### DIFF
--- a/src/library/kernels/csrmm_adaptive.cl
+++ b/src/library/kernels/csrmm_adaptive.cl
@@ -246,7 +246,7 @@ csrmv_batched( global const FPTYPE * restrict sparseVals,
             // This causes a minor performance loss because this is the last workgroup
             // to be launched, and this loop can't be unrolled.
             int max_to_load = sparseRowPtrs[ stop_row ] - sparseRowPtrs[ row ];
-            for( int i = 0; i < max_to_load; i += 256 )
+            for(int i = 0; i < ((int)max_to_load-(int)localID); i += 256)
             {
                 partialSums[ localID + i ] = sparseVals[ col + i ] * denseB[ sparseCols[ col + i ] * ldB ];
             }

--- a/src/library/kernels/csrmv_adaptive.cl
+++ b/src/library/kernels/csrmv_adaptive.cl
@@ -423,7 +423,7 @@ csrmv_adaptive(__global const VALUE_TYPE * restrict const vals,
           // This causes a minor performance loss because this is the last workgroup
           // to be launched, and this loop can't be unrolled.
           const unsigned int max_to_load = rowPtrs[stop_row] - rowPtrs[row];
-          for(int i = 0; i < max_to_load; i += WG_SIZE)
+          for(int i = 0; i < ((int)max_to_load-(int)lid); i += WG_SIZE)
               partialSums[lid + i] = alpha * vals[col + i] * vec[cols[col + i]];
       }
       barrier(CLK_LOCAL_MEM_FENCE);


### PR DESCRIPTION
The last workgroup would potentially reach past the end of the vals and cols arrays, getting garbage.

This caused problems on Nvidia GPUs.

Fixed and verified on an NV GPU.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/clmathlibraries/clsparse/183)
<!-- Reviewable:end -->
