### PR TITLE
Ignore errors / warnings when using deprecated cl1.2 functions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,8 @@
 # PUBLIC keywords
 cmake_minimum_required( VERSION 2.8.12 )
 
+add_definitions(-DCL_USE_DEPRECATED_OPENCL_1_2_APIS)
+
 if( CMAKE_GENERATOR MATCHES "NMake" )
 	option( NMAKE_COMPILE_VERBOSE "Print VERBOSE compile/link msgs to the console" OFF )
 	if( NMAKE_COMPILE_VERBOSE )


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/clmathlibraries/clsparse/189)
<!-- Reviewable:end -->
