### PR TITLE
Fix invalid memory access on Nvidia GPUs in CSR-Adaptive SpMV kernel

### DIFF
--- a/src/library/kernels/csrmv_adaptive.cl
+++ b/src/library/kernels/csrmv_adaptive.cl
@@ -423,7 +423,7 @@ csrmv_adaptive(__global const VALUE_TYPE * restrict const vals,
           // This causes a minor performance loss because this is the last workgroup
           // to be launched, and this loop can't be unrolled.
           const unsigned int max_to_load = rowPtrs[stop_row] - rowPtrs[row];
-          for(int i = 0; i < max_to_load; i += WG_SIZE)
+          for(int i = 0; col+i < rowPtrs[stop_row]; i += WG_SIZE)
               partialSums[lid + i] = alpha * vals[col + i] * vec[cols[col + i]];
       }
       barrier(CLK_LOCAL_MEM_FENCE);

--- a/src/library/kernels/csrmv_adaptive.cl
+++ b/src/library/kernels/csrmv_adaptive.cl
@@ -422,7 +422,6 @@ csrmv_adaptive(__global const VALUE_TYPE * restrict const vals,
           // However, this may change in the future (e.g. with shared virtual memory.)
           // This causes a minor performance loss because this is the last workgroup
           // to be launched, and this loop can't be unrolled.
-          const unsigned int max_to_load = rowPtrs[stop_row] - rowPtrs[row];
           for(int i = 0; col+i < rowPtrs[stop_row]; i += WG_SIZE)
               partialSums[lid + i] = alpha * vals[col + i] * vec[cols[col + i]];
       }


### PR DESCRIPTION
I observed an invalid memory access with clSPARSE and CUDA 7.5 on an Nvidia Tesla K20m.
The CSR-Adaptive SpMV kernel returned -9999 for some input matrices.

This is fixed by not accessing vals and cols beyond rowPtrs[stop_row].
The previous workaround didn't prevent this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/clmathlibraries/clsparse/191)
<!-- Reviewable:end -->
