### PR TITLE
Fix invalid memory access on Nvidia GPUs in CSR-Adaptive SpMV kernel

### DIFF
--- a/src/library/kernels/csrmv_adaptive.cl
+++ b/src/library/kernels/csrmv_adaptive.cl
@@ -422,8 +422,7 @@ csrmv_adaptive(__global const VALUE_TYPE * restrict const vals,
           // However, this may change in the future (e.g. with shared virtual memory.)
           // This causes a minor performance loss because this is the last workgroup
           // to be launched, and this loop can't be unrolled.
-          const unsigned int max_to_load = rowPtrs[stop_row] - rowPtrs[row];
-          for(int i = 0; i < ((int)max_to_load-(int)lid); i += WG_SIZE)
+          for(int i = 0; col+i < rowPtrs[stop_row]; i += WG_SIZE)
               partialSums[lid + i] = alpha * vals[col + i] * vec[cols[col + i]];
       }
       barrier(CLK_LOCAL_MEM_FENCE);


### PR DESCRIPTION
This is a copy of pull request #191 but on the correct branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/clmathlibraries/clsparse/192)
<!-- Reviewable:end -->
