### PR TITLE
Fix the kernel wrapper for cl2.hpp.

### DIFF
--- a/src/library/internal/kernel-wrap.hpp
+++ b/src/library/internal/kernel-wrap.hpp
@@ -78,9 +78,7 @@ public:
         assert(argCounter < kernel.getInfo<CL_KERNEL_NUM_ARGS>());
 
         cl_int status = 0;
-        status = kernel.setArg(argCounter++, sizeof(cl_mem), (const void*)val);
-
-
+        status = kernel.setArg(argCounter++, sizeof(cl_mem), (const void*)&val);
         return *this;
     }
 


### PR DESCRIPTION
We must pass the address of the cl_mem argument, not the cl_mem itself.

Without this patch, we currently segfault when trying to run kernels that use a cl_mem argument. We essentially end up passing garbage into clSetKernelArg()'s argument variable.

Tested on test-blas2 and test-blas3 with Linux AMD APP SDK 3.0 and fglrx drivers.