### PR TITLE
External project fixs

### DIFF
--- a/cmake/ExternalBoost.cmake
+++ b/cmake/ExternalBoost.cmake
@@ -91,11 +91,11 @@ elseif( MSVC14 )
   list( APPEND Boost.Command toolset=msvc-14.0 )
 elseif( XCODE_VERSION )
   list( APPEND Boost.Command toolset=clang )
-elseif( DEFINED ENV{CC} )
+elseif( ENV{CC} )
   # CMake apprarently puts the full path of the compiler into CC
   # The user might specify a non-default gcc compiler through ENV
   message( STATUS "ENV{CC}=$ENV{CC}" )
-  get_filename_component( gccToolset $ENV{CC} NAME )
+  get_filename_component( gccToolset "$ENV{CC}" NAME )
 
   # see: https://svn.boost.org/trac/boost/ticket/5917
   string( TOLOWER ${gccToolset} gccToolset )

--- a/cmake/ExternalGmock.cmake
+++ b/cmake/ExternalGmock.cmake
@@ -25,7 +25,7 @@ message( STATUS "ext.gMock_Version: " ${ext.gMock_Version} )
 if( DEFINED ENV{GMOCK_URL} )
   set( ext.gMock_URL "$ENV{GMOCK_URL}" CACHE STRING "URL to download gMock from" )
 else( )
-  set( ext.gMock_URL "https://googlemock.googlecode.com/files/gmock-${ext.gMock_Version}.zip" CACHE STRING "URL to download gMock from" )
+  set( ext.gMock_URL "https://github.com/google/googletest/archive/release-${ext.gMock_Version}.zip" CACHE STRING "URL to download gMock from" )
 endif( )
 mark_as_advanced( ext.gMock_URL )
 
@@ -91,7 +91,7 @@ endif( )
 ExternalProject_Add(
   gMock
   URL ${ext.gMock_URL}
-  URL_MD5 073b984d8798ea1594f5e44d85b20d66
+  URL_MD5 ef5e700c8a0f3ee123e2e0209b8b4961
   CMAKE_ARGS ${ext.gMock.cmake_args} -DCMAKE_DEBUG_POSTFIX=d
   BUILD_COMMAND ${ext.gMock.Make}
   INSTALL_COMMAND ""


### PR DESCRIPTION
Fixed googlemock external to download gtest release from github external
Modified boost external to detect ENV{CC} in a more careful manner, wrapping environment variable in a string which behaves better on macosx