### PR TITLE
Add support for AltiVec.

### DIFF
--- a/src/include/clSPARSE-error.h
+++ b/src/include/clSPARSE-error.h
@@ -23,6 +23,11 @@
 #ifndef _CLSPARSE_ERROR_H_
 #define _CLSPARSE_ERROR_H_
 
+#ifdef __ALTIVEC__
+#undef bool
+#undef vector
+#endif
+
 #if defined(__APPLE__) || defined(__MACOSX)
 #   include <OpenCL/cl.h>
 #else

--- a/src/include/clSPARSE.h
+++ b/src/include/clSPARSE.h
@@ -24,6 +24,12 @@
 #ifndef _CL_SPARSE_H_
 #define _CL_SPARSE_H_
 
+#ifdef __ALTIVEC__
+#include <altivec.h>
+#undef bool
+#undef vector
+#endif
+
 // CMake-generated file to define export related preprocessor macros
 #include "clsparse_export.h"
 

--- a/src/library/internal/kernel-cache.hpp
+++ b/src/library/internal/kernel-cache.hpp
@@ -23,6 +23,12 @@
 #define CL_HPP_MINIMUM_OPENCL_VERSION BUILD_CLVERSION
 #define CL_HPP_TARGET_OPENCL_VERSION BUILD_CLVERSION
 
+#ifdef __ALTIVEC__
+#include <altivec.h>
+#undef bool
+#undef vector
+#endif
+
 #include <CL/cl2.hpp>
 
 #include <string>

--- a/src/library/internal/kernel-wrap.hpp
+++ b/src/library/internal/kernel-wrap.hpp
@@ -22,6 +22,12 @@
 #define CL_HPP_MINIMUM_OPENCL_VERSION BUILD_CLVERSION
 #define CL_HPP_TARGET_OPENCL_VERSION BUILD_CLVERSION
 
+#ifdef __ALTIVEC__
+#include <altivec.h>
+#undef bool
+#undef vector
+#endif
+
 #include <CL/cl2.hpp>
 
 #include <iostream>

--- a/src/library/internal/ocl-type-traits.hpp
+++ b/src/library/internal/ocl-type-traits.hpp
@@ -17,6 +17,12 @@
 #ifndef OCL_TYPE_TRAITS_HPP_
 #define OCL_TYPE_TRAITS_HPP_
 
+#ifdef __ALTIVEC__
+#include <altivec.h>
+#undef bool
+#undef vector
+#endif
+
 #include <type_traits>
 
 #if defined(__APPLE__) || defined(__MACOSX)


### PR DESCRIPTION
Just forwarding a downstream patch which enables builds of clSPARSE on PowerPC architectures.

It is fairly standard fix, whereby the conflicting `bool` and `vector` macros defined in the AltiVec headers are unset after inclusion to avoid conflict with the regular types of the standard library.