### PR TITLE
Remove unused broken GetTypecode to allow building with GCC 8

### DIFF
--- a/src/benchmarks/cusparse-bench/src/mm_reader.cpp
+++ b/src/benchmarks/cusparse-bench/src/mm_reader.cpp
@@ -103,11 +103,6 @@ public:
         return isSymmetric;
     }
 
-    char &GetTypecode( )
-    {
-        return Typecode;
-    }
-
     Coordinate<FloatType> *GetUnsymCoordinates( )
     {
         return unsym_coords;

--- a/src/library/io/mm-reader.cpp
+++ b/src/library/io/mm-reader.cpp
@@ -118,11 +118,6 @@ public:
         return isSymmetric;
     }
 
-    char &GetTypecode( )
-    {
-        return Typecode;
-    }
-
     Coordinate<FloatType> *GetUnsymCoordinates( )
     {
         return unsym_coords;


### PR DESCRIPTION
This template function is unused (not in any public headers and not called from within clSPARSE), and has always been non-instantiable (and hence unusable) as char[4] to char& is an invalid conversion.

Older GCC didn't notice as we never try (instantiating a class template [only instantiates those member functions that are used](https://en.cppreference.com/w/cpp/language/templates)), but in GCC 8 [its existence is an error](https://gcc.gnu.org/gcc-8/porting_to.html#hypothetical-instantiation):

/build/clsparse-0.10.2.0/src/library/io/mm-reader.cpp: In member function 'char& MatrixMarketReader<FloatType>::GetTypecode()':
/build/clsparse-0.10.2.0/src/library/io/mm-reader.cpp:123:16: error: invalid conversion from 'char*' to 'char' [-fpermissive]
         return Typecode;
                ^~~~~~~~
/build/clsparse-0.10.2.0/src/library/io/mm-reader.cpp:123:16: error: cannot bind rvalue '(char)((char*)(&((MatrixMarketReader<FloatType>*)this)->MatrixMarketReader<FloatType>::Typecode))' to 'char&'

An alternative to removal is to change the char & to char *.  Both options build in Debian (gcc 8.2, clsparse 0.10.2.0, where [this problem was previously reported](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=897722)), but have **not** been built in develop or tested anywhere.